### PR TITLE
Normalize JSON-LD schema across site

### DIFF
--- a/2018.html
+++ b/2018.html
@@ -1,7 +1,62 @@
 <!DOCTYPE html>
 <html class="no-js" lang="">
     <head>
-        <!-- Google tag (gtag.js) -->
+        <script type="application/ld+json">
+        {
+          "@context": "https://schema.org",
+          "@graph": [
+            {
+              "@type": "WebSite",
+              "@id": "https://www.stateof.ai/2018#website",
+              "url": "https://www.stateof.ai/",
+              "name": "State of AI Report",
+              "publisher": {
+                "@type": "Organization",
+                "name": "Air Street Capital",
+                "url": "https://www.airstreet.com/"
+              }
+            },
+            {
+              "@type": "CreativeWorkSeries",
+              "@id": "https://www.stateof.ai/2018#series",
+              "name": "State of AI Report",
+              "description": "The most widely read and trusted independent annual report on global progress in artificial intelligence, covering research, industry, geopolitics, and AI safety.",
+              "inLanguage": "en",
+              "startDate": "2018-01-01",
+              "url": "https://www.stateof.ai/2018",
+              "creator": {
+                "@type": "Person",
+                "name": "Nathan Benaich",
+                "url": "https://www.nathanbenaich.com/"
+              },
+              "publisher": {
+                "@type": "Organization",
+                "name": "Air Street Capital",
+                "url": "https://www.airstreet.com/"
+              },
+              "keywords": [
+                "State of AI",
+                "State of AI Report",
+                "artificial intelligence",
+                "machine learning",
+                "deep learning",
+                "generative AI",
+                "AI research",
+                "AI industry",
+                "AI geopolitics",
+                "AI safety"
+              ],
+              "sameAs": [
+                "https://x.com/stateofai",
+                "https://www.linkedin.com/company/stateofai/",
+                "https://press.airstreet.com/",
+                "https://www.airstreet.com/"
+              ]
+            }
+          ]
+        }
+        </script>
+<!-- Google tag (gtag.js) -->
         <script async src="https://www.googletagmanager.com/gtag/js?id=G-25T8JQY0LN"></script>
         <script>
           window.dataLayer = window.dataLayer || [];
@@ -17,34 +72,7 @@
         'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
         })(window,document,'script','dataLayer','GTM-NWC2HDM');</script>
         <!-- End Google Tag Manager -->
-        <script type="application/ld+json">
-        {
-          "@context" : "http://schema.org",
-          "@type" : "Article",
-          "headline" : "A Report on the state of AI and its implication for the future.",
-          "name" : "State of AI Report",
-          "about" : "A Report on artificial intelligence research, talent, politics, industry, startups, and China.",
-          "description" : "A Report on artificial intelligence research, talent, politics, industry, startups, and China.",
-          "inLanguage" : "English",
-          "image" : "https://www.slideshare.net/StateofAIReport/state-of-ai-report-2019-151804430",
-          "keywords" : ["State of AI Report 2020", "State of AI Report 2018", "State of AI Report 2019", "artificial intelligence", "deep learning", "machine learning", "reinforcement learning", "supervised learning", "startups", "venture capital", "State of AI", "State of AI Report", "State of AI Report 2018"],
-          "publisher": {
-            "@type": "Organization",
-            "name": "Air Street Capital"
-          },
-          "author" : [ {
-            "@type" : "Person",
-            "name" : "Nathan Benaich"
-          }, {
-            "@type" : "Person",
-            "name" : "Ian Hogarth"
-          } ],
-          "datePublished" : "2019-06-28",
-          "articleBody" : "We believe that AI will be a force multiplier on technological progress in our increasingly digital, data-driven world. This is because everything around us today, ranging from culture to consumer products, is a product of intelligence.\n              </P>\n              <P class=\"subtext\">\n                In this report, we set out to capture a snapshot of the exponential progress in AI with a focus on developments in the past 12 months. Consider this report as a compilation of the most interesting things we’ve seen that seeks to trigger an informed conversation about the state of AI and its implication for the future. This edition builds on the inaugural State of AI Report 2018, which can be <A href=\"https://www.stateof.ai/2018\">found here</A>.\n              </P>\n              <OL> We consider the following key dimensions in our report:\n                  <LI><STRONG>Research:</STRONG> Technology breakthroughs and their capabilities. </LI>\n                  <LI><STRONG>Talent:</STRONG> Supply, demand and concentration of talent working in the field.  </LI>\n                  <LI><STRONG>Industry:</STRONG> Large platforms, financings and areas of application for AI-driven innovation today and tomorrow. </LI>\n                  <LI><STRONG>China:</STRONG> With two distinct internets, we review AI in China as its own category. </LI>\n                  <LI><STRONG>Politics:</STRONG> Public opinion of AI, economic implications and the emerging geopolitics of AI.",
-          "url" : "https://www.slideshare.net/StateofAIReport/state-of-ai-report-2019-151804430"
-        }
-        </script>
-        <title>State of AI Report 2018</title>
+<title>State of AI Report 2018</title>
         <meta charset="utf-8">
         <meta http-equiv="x-ua-compatible" content="ie=edge">
         <meta name="author" content="Nathan Benaich and Ian Hogarth">

--- a/2019.html
+++ b/2019.html
@@ -1,7 +1,62 @@
 <!DOCTYPE html>
 <html class="no-js" lang="">
     <head>
-        <!-- Google tag (gtag.js) -->
+        <script type="application/ld+json">
+        {
+          "@context": "https://schema.org",
+          "@graph": [
+            {
+              "@type": "WebSite",
+              "@id": "https://www.stateof.ai/2019#website",
+              "url": "https://www.stateof.ai/",
+              "name": "State of AI Report",
+              "publisher": {
+                "@type": "Organization",
+                "name": "Air Street Capital",
+                "url": "https://www.airstreet.com/"
+              }
+            },
+            {
+              "@type": "CreativeWorkSeries",
+              "@id": "https://www.stateof.ai/2019#series",
+              "name": "State of AI Report",
+              "description": "The most widely read and trusted independent annual report on global progress in artificial intelligence, covering research, industry, geopolitics, and AI safety.",
+              "inLanguage": "en",
+              "startDate": "2018-01-01",
+              "url": "https://www.stateof.ai/2019",
+              "creator": {
+                "@type": "Person",
+                "name": "Nathan Benaich",
+                "url": "https://www.nathanbenaich.com/"
+              },
+              "publisher": {
+                "@type": "Organization",
+                "name": "Air Street Capital",
+                "url": "https://www.airstreet.com/"
+              },
+              "keywords": [
+                "State of AI",
+                "State of AI Report",
+                "artificial intelligence",
+                "machine learning",
+                "deep learning",
+                "generative AI",
+                "AI research",
+                "AI industry",
+                "AI geopolitics",
+                "AI safety"
+              ],
+              "sameAs": [
+                "https://x.com/stateofai",
+                "https://www.linkedin.com/company/stateofai/",
+                "https://press.airstreet.com/",
+                "https://www.airstreet.com/"
+              ]
+            }
+          ]
+        }
+        </script>
+<!-- Google tag (gtag.js) -->
         <script async src="https://www.googletagmanager.com/gtag/js?id=G-25T8JQY0LN"></script>
         <script>
           window.dataLayer = window.dataLayer || [];
@@ -17,34 +72,7 @@
         'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
         })(window,document,'script','dataLayer','GTM-NWC2HDM');</script>
         <!-- End Google Tag Manager -->
-        <script type="application/ld+json">
-        {
-          "@context" : "http://schema.org",
-          "@type" : "Article",
-          "headline" : "A Report on the state of AI and its implication for the future.",
-          "name" : "State of AI Report",
-          "about" : "A Report on artificial intelligence research, talent, politics, industry, startups, and China.",
-          "description" : "A Report on artificial intelligence research, talent, politics, industry, startups, and China.",
-          "inLanguage" : "English",
-          "image" : "https://www.slideshare.net/StateofAIReport/state-of-ai-report-2019-151804430",
-          "keywords" : ["State of AI Report 2020", "State of AI Report 2018", "State of AI Report 2019", "artificial intelligence", "deep learning", "machine learning", "reinforcement learning", "supervised learning", "startups", "venture capital", "State of AI", "State of AI Report", "State of AI Report 2018"],
-          "publisher": {
-            "@type": "Organization",
-            "name": "Air Street Capital"
-          },
-          "author" : [ {
-            "@type" : "Person",
-            "name" : "Nathan Benaich"
-          }, {
-            "@type" : "Person",
-            "name" : "Ian Hogarth"
-          } ],
-          "datePublished" : "2019-06-28",
-          "articleBody" : "We believe that AI will be a force multiplier on technological progress in our increasingly digital, data-driven world. This is because everything around us today, ranging from culture to consumer products, is a product of intelligence.\n              </P>\n              <P class=\"subtext\">\n                In this report, we set out to capture a snapshot of the exponential progress in AI with a focus on developments in the past 12 months. Consider this report as a compilation of the most interesting things we’ve seen that seeks to trigger an informed conversation about the state of AI and its implication for the future. This edition builds on the inaugural State of AI Report 2018, which can be <A href=\"https://www.stateof.ai/2018\">found here</A>.\n              </P>\n              <OL> We consider the following key dimensions in our report:\n                  <LI><STRONG>Research:</STRONG> Technology breakthroughs and their capabilities. </LI>\n                  <LI><STRONG>Talent:</STRONG> Supply, demand and concentration of talent working in the field.  </LI>\n                  <LI><STRONG>Industry:</STRONG> Large platforms, financings and areas of application for AI-driven innovation today and tomorrow. </LI>\n                  <LI><STRONG>China:</STRONG> With two distinct internets, we review AI in China as its own category. </LI>\n                  <LI><STRONG>Politics:</STRONG> Public opinion of AI, economic implications and the emerging geopolitics of AI.",
-          "url" : "https://www.slideshare.net/StateofAIReport/state-of-ai-report-2019-151804430"
-        }
-        </script>
-        <title>State of AI Report 2019</title>
+<title>State of AI Report 2019</title>
         <meta charset="utf-8">
         <meta http-equiv="x-ua-compatible" content="ie=edge">
         <meta name="author" content="Nathan Benaich and Ian Hogarth">

--- a/2020.html
+++ b/2020.html
@@ -1,7 +1,62 @@
 <!DOCTYPE html>
 <html class="no-js" lang="">
     <head>
-        <!-- Google tag (gtag.js) -->
+        <script type="application/ld+json">
+        {
+          "@context": "https://schema.org",
+          "@graph": [
+            {
+              "@type": "WebSite",
+              "@id": "https://www.stateof.ai/2020#website",
+              "url": "https://www.stateof.ai/",
+              "name": "State of AI Report",
+              "publisher": {
+                "@type": "Organization",
+                "name": "Air Street Capital",
+                "url": "https://www.airstreet.com/"
+              }
+            },
+            {
+              "@type": "CreativeWorkSeries",
+              "@id": "https://www.stateof.ai/2020#series",
+              "name": "State of AI Report",
+              "description": "The most widely read and trusted independent annual report on global progress in artificial intelligence, covering research, industry, geopolitics, and AI safety.",
+              "inLanguage": "en",
+              "startDate": "2018-01-01",
+              "url": "https://www.stateof.ai/2020",
+              "creator": {
+                "@type": "Person",
+                "name": "Nathan Benaich",
+                "url": "https://www.nathanbenaich.com/"
+              },
+              "publisher": {
+                "@type": "Organization",
+                "name": "Air Street Capital",
+                "url": "https://www.airstreet.com/"
+              },
+              "keywords": [
+                "State of AI",
+                "State of AI Report",
+                "artificial intelligence",
+                "machine learning",
+                "deep learning",
+                "generative AI",
+                "AI research",
+                "AI industry",
+                "AI geopolitics",
+                "AI safety"
+              ],
+              "sameAs": [
+                "https://x.com/stateofai",
+                "https://www.linkedin.com/company/stateofai/",
+                "https://press.airstreet.com/",
+                "https://www.airstreet.com/"
+              ]
+            }
+          ]
+        }
+        </script>
+<!-- Google tag (gtag.js) -->
         <script async src="https://www.googletagmanager.com/gtag/js?id=G-25T8JQY0LN"></script>
         <script>
           window.dataLayer = window.dataLayer || [];
@@ -17,33 +72,7 @@
         'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
         })(window,document,'script','dataLayer','GTM-NWC2HDM');</script>
         <!-- End Google Tag Manager -->
-        <script type="application/ld+json">
-        {
-          "@context" : "http://schema.org",
-          "@type" : "Article",
-          "headline" : "A Report on the state of AI and its implication for the future.",
-          "name" : "State of AI Report",
-          "about" : "A Report on artificial intelligence research, talent, politics, industry, startups, and China.",
-          "description" : "A Report on artificial intelligence research, talent, politics, industry, startups, and China.",
-          "inLanguage" : "English",
-          "keywords" : ["State of AI Report 2021", "State of AI Report 2020", "State of AI Report 2018", "State of AI Report 2019", "artificial intelligence", "deep learning", "machine learning", "reinforcement learning", "supervised learning", "startups", "venture capital", "State of AI", "State of AI Report", "State of AI Report 2018"],
-          "publisher": {
-            "@type": "Organization",
-            "name": "Air Street Capital"
-          },
-          "author" : [ {
-            "@type" : "Person",
-            "name" : "Nathan Benaich"
-          }, {
-            "@type" : "Person",
-            "name" : "Ian Hogarth"
-          } ],
-          "datePublished" : "2020-10-01",
-          "articleBody" : "We believe that AI will be a force multiplier on technological progress in our increasingly digital, data-driven world. This is because everything around us today, ranging from culture to consumer products, is a product of intelligence.\n              </P>\n              <P class=\"subtext\">\n                In this report, we set out to capture a snapshot of the exponential progress in AI with a focus on developments in the past 12 months. Consider this report as a compilation of the most interesting things we’ve seen that seeks to trigger an informed conversation about the state of AI and its implication for the future. This edition builds on the State of AI Report 2019, which can be <A href=\"https://www.stateof.ai/2019\">found here</A>.\n              </P>\n              <OL> We consider the following key dimensions in our report:\n                  <LI><STRONG>Research:</STRONG> Technology breakthroughs and their capabilities. </LI>\n                  <LI><STRONG>Talent:</STRONG> Supply, demand and concentration of talent working in the field.  </LI>\n                  <LI><STRONG>Industry:</STRONG> Large platforms, financings and areas of application for AI-driven innovation today and tomorrow. </LI>\n                  <LI><STRONG>China:</STRONG> With two distinct internets, we review AI in China as its own category. </LI>\n                  <LI><STRONG>Politics:</STRONG> Public opinion of AI, economic implications and the emerging geopolitics of AI.",
-          "url" : "https://www.stateof.ai/2020"
-        }
-        </script>
-        <title>State of AI Report 2020</title>
+<title>State of AI Report 2020</title>
         <meta charset="utf-8">
         <meta http-equiv="x-ua-compatible" content="ie=edge">
         <meta name="author" content="Nathan Benaich and Ian Hogarth">

--- a/2020stagingkljasdn2904alkn.html
+++ b/2020stagingkljasdn2904alkn.html
@@ -1,7 +1,62 @@
 <!DOCTYPE html>
 <html class="no-js" lang="">
     <head>
-        <!-- Google tag (gtag.js) -->
+        <script type="application/ld+json">
+        {
+          "@context": "https://schema.org",
+          "@graph": [
+            {
+              "@type": "WebSite",
+              "@id": "https://www.stateof.ai/2020stagingkljasdn2904alkn#website",
+              "url": "https://www.stateof.ai/",
+              "name": "State of AI Report",
+              "publisher": {
+                "@type": "Organization",
+                "name": "Air Street Capital",
+                "url": "https://www.airstreet.com/"
+              }
+            },
+            {
+              "@type": "CreativeWorkSeries",
+              "@id": "https://www.stateof.ai/2020stagingkljasdn2904alkn#series",
+              "name": "State of AI Report",
+              "description": "The most widely read and trusted independent annual report on global progress in artificial intelligence, covering research, industry, geopolitics, and AI safety.",
+              "inLanguage": "en",
+              "startDate": "2018-01-01",
+              "url": "https://www.stateof.ai/2020stagingkljasdn2904alkn",
+              "creator": {
+                "@type": "Person",
+                "name": "Nathan Benaich",
+                "url": "https://www.nathanbenaich.com/"
+              },
+              "publisher": {
+                "@type": "Organization",
+                "name": "Air Street Capital",
+                "url": "https://www.airstreet.com/"
+              },
+              "keywords": [
+                "State of AI",
+                "State of AI Report",
+                "artificial intelligence",
+                "machine learning",
+                "deep learning",
+                "generative AI",
+                "AI research",
+                "AI industry",
+                "AI geopolitics",
+                "AI safety"
+              ],
+              "sameAs": [
+                "https://x.com/stateofai",
+                "https://www.linkedin.com/company/stateofai/",
+                "https://press.airstreet.com/",
+                "https://www.airstreet.com/"
+              ]
+            }
+          ]
+        }
+        </script>
+<!-- Google tag (gtag.js) -->
         <script async src="https://www.googletagmanager.com/gtag/js?id=G-25T8JQY0LN"></script>
         <script>
           window.dataLayer = window.dataLayer || [];
@@ -17,34 +72,7 @@
         'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
         })(window,document,'script','dataLayer','GTM-NWC2HDM');</script>
         <!-- End Google Tag Manager -->
-        <script type="application/ld+json">
-        {
-          "@context" : "http://schema.org",
-          "@type" : "Article",
-          "headline" : "A Report on the state of AI and its implication for the future.",
-          "name" : "State of AI Report",
-          "about" : "A Report on artificial intelligence research, talent, politics, industry, startups, and China.",
-          "description" : "A Report on artificial intelligence research, talent, politics, industry, startups, and China.",
-          "inLanguage" : "English",
-          "image" : "https://www.slideshare.net/StateofAIReport/state-of-ai-report-2019-151804430",
-          "keywords" : ["State of AI Report 2020", "State of AI Report 2018", "State of AI Report 2019", "artificial intelligence", "deep learning", "machine learning", "reinforcement learning", "supervised learning", "startups", "venture capital", "State of AI", "State of AI Report", "State of AI Report 2018"],
-          "publisher": {
-            "@type": "Organization",
-            "name": "Air Street Capital"
-          },
-          "author" : [ {
-            "@type" : "Person",
-            "name" : "Nathan Benaich"
-          }, {
-            "@type" : "Person",
-            "name" : "Ian Hogarth"
-          } ],
-          "datePublished" : "2019-06-28",
-          "articleBody" : "We believe that AI will be a force multiplier on technological progress in our increasingly digital, data-driven world. This is because everything around us today, ranging from culture to consumer products, is a product of intelligence.\n              </P>\n              <P class=\"subtext\">\n                In this report, we set out to capture a snapshot of the exponential progress in AI with a focus on developments in the past 12 months. Consider this report as a compilation of the most interesting things we’ve seen that seeks to trigger an informed conversation about the state of AI and its implication for the future. This edition builds on the inaugural State of AI Report 2018, which can be <A href=\"https://www.stateof.ai/2018\">found here</A>.\n              </P>\n              <OL> We consider the following key dimensions in our report:\n                  <LI><STRONG>Research:</STRONG> Technology breakthroughs and their capabilities. </LI>\n                  <LI><STRONG>Talent:</STRONG> Supply, demand and concentration of talent working in the field.  </LI>\n                  <LI><STRONG>Industry:</STRONG> Large platforms, financings and areas of application for AI-driven innovation today and tomorrow. </LI>\n                  <LI><STRONG>China:</STRONG> With two distinct internets, we review AI in China as its own category. </LI>\n                  <LI><STRONG>Politics:</STRONG> Public opinion of AI, economic implications and the emerging geopolitics of AI.",
-          "url" : "https://www.slideshare.net/StateofAIReport/state-of-ai-report-2019-151804430"
-        }
-        </script>
-        <title>State of AI Report 2020</title>
+<title>State of AI Report 2020</title>
         <meta charset="utf-8">
         <meta http-equiv="x-ua-compatible" content="ie=edge">
         <meta name="author" content="Nathan Benaich and Ian Hogarth">

--- a/2021-report-launch.html
+++ b/2021-report-launch.html
@@ -1,7 +1,62 @@
 <!DOCTYPE html>
 <html class="no-js" lang="">
     <head>
-        <!-- Google tag (gtag.js) -->
+        <script type="application/ld+json">
+        {
+          "@context": "https://schema.org",
+          "@graph": [
+            {
+              "@type": "WebSite",
+              "@id": "https://www.stateof.ai/2021-report-launch#website",
+              "url": "https://www.stateof.ai/",
+              "name": "State of AI Report",
+              "publisher": {
+                "@type": "Organization",
+                "name": "Air Street Capital",
+                "url": "https://www.airstreet.com/"
+              }
+            },
+            {
+              "@type": "CreativeWorkSeries",
+              "@id": "https://www.stateof.ai/2021-report-launch#series",
+              "name": "State of AI Report",
+              "description": "The most widely read and trusted independent annual report on global progress in artificial intelligence, covering research, industry, geopolitics, and AI safety.",
+              "inLanguage": "en",
+              "startDate": "2018-01-01",
+              "url": "https://www.stateof.ai/2021-report-launch",
+              "creator": {
+                "@type": "Person",
+                "name": "Nathan Benaich",
+                "url": "https://www.nathanbenaich.com/"
+              },
+              "publisher": {
+                "@type": "Organization",
+                "name": "Air Street Capital",
+                "url": "https://www.airstreet.com/"
+              },
+              "keywords": [
+                "State of AI",
+                "State of AI Report",
+                "artificial intelligence",
+                "machine learning",
+                "deep learning",
+                "generative AI",
+                "AI research",
+                "AI industry",
+                "AI geopolitics",
+                "AI safety"
+              ],
+              "sameAs": [
+                "https://x.com/stateofai",
+                "https://www.linkedin.com/company/stateofai/",
+                "https://press.airstreet.com/",
+                "https://www.airstreet.com/"
+              ]
+            }
+          ]
+        }
+        </script>
+<!-- Google tag (gtag.js) -->
         <script async src="https://www.googletagmanager.com/gtag/js?id=G-25T8JQY0LN"></script>
         <script>
           window.dataLayer = window.dataLayer || [];
@@ -17,33 +72,7 @@
         'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
         })(window,document,'script','dataLayer','GTM-NWC2HDM');</script>
         <!-- End Google Tag Manager -->
-        <script type="application/ld+json">
-        {
-          "@context" : "http://schema.org",
-          "@type" : "Article",
-          "headline" : "A Report on the state of AI and its implication for the future.",
-          "name" : "State of AI Report",
-          "about" : "A Report on artificial intelligence research, talent, politics, industry, startups, and China.",
-          "description" : "A Report on artificial intelligence research, talent, politics, industry, startups, and China.",
-          "inLanguage" : "English",
-          "keywords" : ["State of AI Report 2021", "State of AI Report 2020", "State of AI Report 2018", "State of AI Report 2019", "artificial intelligence", "deep learning", "machine learning", "reinforcement learning", "supervised learning", "startups", "venture capital", "State of AI", "State of AI Report", "State of AI Report 2018"],
-          "publisher": {
-            "@type": "Organization",
-            "name": "Air Street Capital"
-          },
-          "author" : [ {
-            "@type" : "Person",
-            "name" : "Nathan Benaich"
-          }, {
-            "@type" : "Person",
-            "name" : "Ian Hogarth"
-          } ],
-          "datePublished" : "2021-10-12",
-          "articleBody" : "We believe that AI will be a force multiplier on technological progress in our increasingly digital, data-driven world. This is because everything around us today, ranging from culture to consumer products, is a product of intelligence.\n              </P>\n              <P class=\"subtext\">\n                In this report, we set out to capture a snapshot of the exponential progress in AI with a focus on developments in the past 12 months. Consider this report as a compilation of the most interesting things we’ve seen that seeks to trigger an informed conversation about the state of AI and its implication for the future. This edition builds on the State of AI Report 2021, which can be <A href=\"https://www.stateof.ai/2018\">found here</A>.\n              </P>\n              <OL> We consider the following key dimensions in our report:\n                  <LI><STRONG>Research:</STRONG> Technology breakthroughs and their capabilities. </LI>\n                  <LI><STRONG>Talent:</STRONG> Supply, demand and concentration of talent working in the field.  </LI>\n                  <LI><STRONG>Industry:</STRONG> Large platforms, financings and areas of application for AI-driven innovation today and tomorrow. </LI>\n                  <LI><STRONG>China:</STRONG> With two distinct internets, we review AI in China as its own category. </LI>\n                  <LI><STRONG>Politics:</STRONG> Public opinion of AI, economic implications and the emerging geopolitics of AI.",
-          "url" : "https://www.stateof.ai"
-        }
-        </script>
-        <title>Welcome to State of AI Report 2021</title>
+<title>Welcome to State of AI Report 2021</title>
         <meta charset="utf-8">
         <meta http-equiv="x-ua-compatible" content="ie=edge">
         <meta name="author" content="Nathan Benaich and Ian Hogarth">

--- a/2021.html
+++ b/2021.html
@@ -1,7 +1,62 @@
 <!DOCTYPE html>
 <html class="no-js" lang="">
     <head>
-        <!-- Google tag (gtag.js) -->
+        <script type="application/ld+json">
+        {
+          "@context": "https://schema.org",
+          "@graph": [
+            {
+              "@type": "WebSite",
+              "@id": "https://www.stateof.ai/2021#website",
+              "url": "https://www.stateof.ai/",
+              "name": "State of AI Report",
+              "publisher": {
+                "@type": "Organization",
+                "name": "Air Street Capital",
+                "url": "https://www.airstreet.com/"
+              }
+            },
+            {
+              "@type": "CreativeWorkSeries",
+              "@id": "https://www.stateof.ai/2021#series",
+              "name": "State of AI Report",
+              "description": "The most widely read and trusted independent annual report on global progress in artificial intelligence, covering research, industry, geopolitics, and AI safety.",
+              "inLanguage": "en",
+              "startDate": "2018-01-01",
+              "url": "https://www.stateof.ai/2021",
+              "creator": {
+                "@type": "Person",
+                "name": "Nathan Benaich",
+                "url": "https://www.nathanbenaich.com/"
+              },
+              "publisher": {
+                "@type": "Organization",
+                "name": "Air Street Capital",
+                "url": "https://www.airstreet.com/"
+              },
+              "keywords": [
+                "State of AI",
+                "State of AI Report",
+                "artificial intelligence",
+                "machine learning",
+                "deep learning",
+                "generative AI",
+                "AI research",
+                "AI industry",
+                "AI geopolitics",
+                "AI safety"
+              ],
+              "sameAs": [
+                "https://x.com/stateofai",
+                "https://www.linkedin.com/company/stateofai/",
+                "https://press.airstreet.com/",
+                "https://www.airstreet.com/"
+              ]
+            }
+          ]
+        }
+        </script>
+<!-- Google tag (gtag.js) -->
         <script async src="https://www.googletagmanager.com/gtag/js?id=G-25T8JQY0LN"></script>
         <script>
           window.dataLayer = window.dataLayer || [];
@@ -17,33 +72,7 @@
         'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
         })(window,document,'script','dataLayer','GTM-NWC2HDM');</script>
         <!-- End Google Tag Manager -->
-        <script type="application/ld+json">
-        {
-          "@context" : "http://schema.org",
-          "@type" : "Article",
-          "headline" : "A Report on the state of AI and its implication for the future.",
-          "name" : "State of AI Report",
-          "about" : "A Report on artificial intelligence research, talent, politics, industry, startups, and China.",
-          "description" : "A Report on artificial intelligence research, talent, politics, industry, startups, and China.",
-          "inLanguage" : "English",
-          "keywords" : ["State of AI Report 2021", "State of AI Report 2020", "State of AI Report 2018", "State of AI Report 2019", "artificial intelligence", "deep learning", "machine learning", "reinforcement learning", "supervised learning", "startups", "venture capital", "State of AI", "State of AI Report", "State of AI Report 2018"],
-          "publisher": {
-            "@type": "Organization",
-            "name": "Air Street Capital"
-          },
-          "author" : [ {
-            "@type" : "Person",
-            "name" : "Nathan Benaich"
-          }, {
-            "@type" : "Person",
-            "name" : "Ian Hogarth"
-          } ],
-          "datePublished" : "2021-10-12",
-          "articleBody" : "We believe that AI will be a force multiplier on technological progress in our increasingly digital, data-driven world. This is because everything around us today, ranging from culture to consumer products, is a product of intelligence.\n              </P>\n              <P class=\"subtext\">\n                In this report, we set out to capture a snapshot of the exponential progress in AI with a focus on developments in the past 12 months. Consider this report as a compilation of the most interesting things we’ve seen that seeks to trigger an informed conversation about the state of AI and its implication for the future. This edition builds on the State of AI Report 2021, which can be <A href=\"https://www.stateof.ai/2018\">found here</A>.\n              </P>\n              <OL> We consider the following key dimensions in our report:\n                  <LI><STRONG>Research:</STRONG> Technology breakthroughs and their capabilities. </LI>\n                  <LI><STRONG>Talent:</STRONG> Supply, demand and concentration of talent working in the field.  </LI>\n                  <LI><STRONG>Industry:</STRONG> Large platforms, financings and areas of application for AI-driven innovation today and tomorrow. </LI>\n                  <LI><STRONG>China:</STRONG> With two distinct internets, we review AI in China as its own category. </LI>\n                  <LI><STRONG>Politics:</STRONG> Public opinion of AI, economic implications and the emerging geopolitics of AI.",
-          "url" : "https://www.stateof.ai"
-        }
-        </script>
-        <title>State of AI Report 2021</title>
+<title>State of AI Report 2021</title>
         <meta charset="utf-8">
         <meta http-equiv="x-ua-compatible" content="ie=edge">
         <meta name="author" content="Nathan Benaich and Ian Hogarth">

--- a/2021staging82980hnlakk3.html
+++ b/2021staging82980hnlakk3.html
@@ -1,7 +1,62 @@
 <!DOCTYPE html>
 <html class="no-js" lang="">
     <head>
-        <!-- Google tag (gtag.js) -->
+        <script type="application/ld+json">
+        {
+          "@context": "https://schema.org",
+          "@graph": [
+            {
+              "@type": "WebSite",
+              "@id": "https://www.stateof.ai/2021staging82980hnlakk3#website",
+              "url": "https://www.stateof.ai/",
+              "name": "State of AI Report",
+              "publisher": {
+                "@type": "Organization",
+                "name": "Air Street Capital",
+                "url": "https://www.airstreet.com/"
+              }
+            },
+            {
+              "@type": "CreativeWorkSeries",
+              "@id": "https://www.stateof.ai/2021staging82980hnlakk3#series",
+              "name": "State of AI Report",
+              "description": "The most widely read and trusted independent annual report on global progress in artificial intelligence, covering research, industry, geopolitics, and AI safety.",
+              "inLanguage": "en",
+              "startDate": "2018-01-01",
+              "url": "https://www.stateof.ai/2021staging82980hnlakk3",
+              "creator": {
+                "@type": "Person",
+                "name": "Nathan Benaich",
+                "url": "https://www.nathanbenaich.com/"
+              },
+              "publisher": {
+                "@type": "Organization",
+                "name": "Air Street Capital",
+                "url": "https://www.airstreet.com/"
+              },
+              "keywords": [
+                "State of AI",
+                "State of AI Report",
+                "artificial intelligence",
+                "machine learning",
+                "deep learning",
+                "generative AI",
+                "AI research",
+                "AI industry",
+                "AI geopolitics",
+                "AI safety"
+              ],
+              "sameAs": [
+                "https://x.com/stateofai",
+                "https://www.linkedin.com/company/stateofai/",
+                "https://press.airstreet.com/",
+                "https://www.airstreet.com/"
+              ]
+            }
+          ]
+        }
+        </script>
+<!-- Google tag (gtag.js) -->
         <script async src="https://www.googletagmanager.com/gtag/js?id=G-25T8JQY0LN"></script>
         <script>
           window.dataLayer = window.dataLayer || [];
@@ -17,33 +72,7 @@
         'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
         })(window,document,'script','dataLayer','GTM-NWC2HDM');</script>
         <!-- End Google Tag Manager -->
-        <script type="application/ld+json">
-        {
-          "@context" : "http://schema.org",
-          "@type" : "Article",
-          "headline" : "A Report on the state of AI and its implication for the future.",
-          "name" : "State of AI Report",
-          "about" : "A Report on artificial intelligence research, talent, politics, industry, startups, and China.",
-          "description" : "A Report on artificial intelligence research, talent, politics, industry, startups, and China.",
-          "inLanguage" : "English",
-          "keywords" : ["State of AI Report 2021", "State of AI Report 2020", "State of AI Report 2018", "State of AI Report 2019", "artificial intelligence", "deep learning", "machine learning", "reinforcement learning", "supervised learning", "startups", "venture capital", "State of AI", "State of AI Report", "State of AI Report 2018"],
-          "publisher": {
-            "@type": "Organization",
-            "name": "Air Street Capital"
-          },
-          "author" : [ {
-            "@type" : "Person",
-            "name" : "Nathan Benaich"
-          }, {
-            "@type" : "Person",
-            "name" : "Ian Hogarth"
-          } ],
-          "datePublished" : "2021-10-12",
-          "articleBody" : "We believe that AI will be a force multiplier on technological progress in our increasingly digital, data-driven world. This is because everything around us today, ranging from culture to consumer products, is a product of intelligence.\n              </P>\n              <P class=\"subtext\">\n                In this report, we set out to capture a snapshot of the exponential progress in AI with a focus on developments in the past 12 months. Consider this report as a compilation of the most interesting things we’ve seen that seeks to trigger an informed conversation about the state of AI and its implication for the future. This edition builds on the State of AI Report 2021, which can be <A href=\"https://www.stateof.ai/2018\">found here</A>.\n              </P>\n              <OL> We consider the following key dimensions in our report:\n                  <LI><STRONG>Research:</STRONG> Technology breakthroughs and their capabilities. </LI>\n                  <LI><STRONG>Talent:</STRONG> Supply, demand and concentration of talent working in the field.  </LI>\n                  <LI><STRONG>Industry:</STRONG> Large platforms, financings and areas of application for AI-driven innovation today and tomorrow. </LI>\n                  <LI><STRONG>China:</STRONG> With two distinct internets, we review AI in China as its own category. </LI>\n                  <LI><STRONG>Politics:</STRONG> Public opinion of AI, economic implications and the emerging geopolitics of AI.",
-          "url" : "https://www.stateof.ai"
-        }
-        </script>
-        <title>State of AI Report 2021</title>
+<title>State of AI Report 2021</title>
         <meta charset="utf-8">
         <meta http-equiv="x-ua-compatible" content="ie=edge">
         <meta name="author" content="Nathan Benaich and Ian Hogarth">

--- a/2022-report-launch.html
+++ b/2022-report-launch.html
@@ -1,7 +1,62 @@
 <!DOCTYPE html>
 <html class="no-js" lang="">
     <head>
-        <!-- Google tag (gtag.js) -->
+        <script type="application/ld+json">
+        {
+          "@context": "https://schema.org",
+          "@graph": [
+            {
+              "@type": "WebSite",
+              "@id": "https://www.stateof.ai/2022-report-launch#website",
+              "url": "https://www.stateof.ai/",
+              "name": "State of AI Report",
+              "publisher": {
+                "@type": "Organization",
+                "name": "Air Street Capital",
+                "url": "https://www.airstreet.com/"
+              }
+            },
+            {
+              "@type": "CreativeWorkSeries",
+              "@id": "https://www.stateof.ai/2022-report-launch#series",
+              "name": "State of AI Report",
+              "description": "The most widely read and trusted independent annual report on global progress in artificial intelligence, covering research, industry, geopolitics, and AI safety.",
+              "inLanguage": "en",
+              "startDate": "2018-01-01",
+              "url": "https://www.stateof.ai/2022-report-launch",
+              "creator": {
+                "@type": "Person",
+                "name": "Nathan Benaich",
+                "url": "https://www.nathanbenaich.com/"
+              },
+              "publisher": {
+                "@type": "Organization",
+                "name": "Air Street Capital",
+                "url": "https://www.airstreet.com/"
+              },
+              "keywords": [
+                "State of AI",
+                "State of AI Report",
+                "artificial intelligence",
+                "machine learning",
+                "deep learning",
+                "generative AI",
+                "AI research",
+                "AI industry",
+                "AI geopolitics",
+                "AI safety"
+              ],
+              "sameAs": [
+                "https://x.com/stateofai",
+                "https://www.linkedin.com/company/stateofai/",
+                "https://press.airstreet.com/",
+                "https://www.airstreet.com/"
+              ]
+            }
+          ]
+        }
+        </script>
+<!-- Google tag (gtag.js) -->
         <script async src="https://www.googletagmanager.com/gtag/js?id=G-25T8JQY0LN"></script>
         <script>
           window.dataLayer = window.dataLayer || [];
@@ -17,33 +72,7 @@
         'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
         })(window,document,'script','dataLayer','GTM-NWC2HDM');</script>
         <!-- End Google Tag Manager -->
-        <script type="application/ld+json">
-        {
-          "@context" : "http://schema.org",
-          "@type" : "Article",
-          "headline" : "A Report on the state of AI and its implication for the future.",
-          "name" : "State of AI Report",
-          "about" : "A Report on artificial intelligence research, talent, politics, industry, startups, and China.",
-          "description" : "A Report on artificial intelligence research, talent, politics, industry, startups, and China.",
-          "inLanguage" : "English",
-          "keywords" : ["State of AI Report 2022", State of AI Report 2021", "State of AI Report 2020", "State of AI Report 2018", "State of AI Report 2019", "artificial intelligence", "deep learning", "machine learning", "reinforcement learning", "supervised learning", "startups", "venture capital", "State of AI", "State of AI Report", "State of AI Report 2018"],
-          "publisher": {
-            "@type": "Organization",
-            "name": "Air Street Capital"
-          },
-          "author" : [ {
-            "@type" : "Person",
-            "name" : "Nathan Benaich"
-          }, {
-            "@type" : "Person",
-            "name" : "Ian Hogarth"
-          } ],
-          "datePublished" : "2022-10-11",
-          "articleBody" : "We believe that AI will be a force multiplier on technological progress in our increasingly digital, data-driven world. This is because everything around us today, ranging from culture to consumer products, is a product of intelligence.\n              </P>\n              <P class=\"subtext\">\n                In this report, we set out to capture a snapshot of the exponential progress in AI with a focus on developments in the past 12 months. Consider this report as a compilation of the most interesting things we’ve seen that seeks to trigger an informed conversation about the state of AI and its implication for the future. This edition builds on the State of AI Report 2021, which can be <A href=\"https://www.stateof.ai/2021\">found here</A>.\n              </P>\n              <OL> We consider the following key dimensions in our report:\n                  <LI><STRONG>Research:</STRONG> Technology breakthroughs and their capabilities. </LI>\n                  <LI><STRONG>Talent:</STRONG> Supply, demand and concentration of talent working in the field.  </LI>\n                  <LI><STRONG>Industry:</STRONG> Large platforms, financings and areas of application for AI-driven innovation today and tomorrow. </LI>\n                  <LI><STRONG>Politics:</STRONG> Public opinion of AI, economic implications and the emerging geopolitics of AI. </LI>\n                  <LI><STRONG>Safety:</STRONG> How to ensure that highly-capable systems are aligned with our species.",
-          "url" : "https://www.stateof.ai"
-        }
-        </script>
-        <title>Welcome to State of AI Report 2022</title>
+<title>Welcome to State of AI Report 2022</title>
         <meta charset="utf-8">
         <meta http-equiv="x-ua-compatible" content="ie=edge">
         <meta name="author" content="Nathan Benaich and Ian Hogarth">

--- a/2022.html
+++ b/2022.html
@@ -1,7 +1,62 @@
 <!DOCTYPE html>
 <html class="no-js" lang="">
     <head>
-        <!-- Google tag (gtag.js) -->
+        <script type="application/ld+json">
+        {
+          "@context": "https://schema.org",
+          "@graph": [
+            {
+              "@type": "WebSite",
+              "@id": "https://www.stateof.ai/2022#website",
+              "url": "https://www.stateof.ai/",
+              "name": "State of AI Report",
+              "publisher": {
+                "@type": "Organization",
+                "name": "Air Street Capital",
+                "url": "https://www.airstreet.com/"
+              }
+            },
+            {
+              "@type": "CreativeWorkSeries",
+              "@id": "https://www.stateof.ai/2022#series",
+              "name": "State of AI Report",
+              "description": "The most widely read and trusted independent annual report on global progress in artificial intelligence, covering research, industry, geopolitics, and AI safety.",
+              "inLanguage": "en",
+              "startDate": "2018-01-01",
+              "url": "https://www.stateof.ai/2022",
+              "creator": {
+                "@type": "Person",
+                "name": "Nathan Benaich",
+                "url": "https://www.nathanbenaich.com/"
+              },
+              "publisher": {
+                "@type": "Organization",
+                "name": "Air Street Capital",
+                "url": "https://www.airstreet.com/"
+              },
+              "keywords": [
+                "State of AI",
+                "State of AI Report",
+                "artificial intelligence",
+                "machine learning",
+                "deep learning",
+                "generative AI",
+                "AI research",
+                "AI industry",
+                "AI geopolitics",
+                "AI safety"
+              ],
+              "sameAs": [
+                "https://x.com/stateofai",
+                "https://www.linkedin.com/company/stateofai/",
+                "https://press.airstreet.com/",
+                "https://www.airstreet.com/"
+              ]
+            }
+          ]
+        }
+        </script>
+<!-- Google tag (gtag.js) -->
         <script async src="https://www.googletagmanager.com/gtag/js?id=G-25T8JQY0LN"></script>
         <script>
           window.dataLayer = window.dataLayer || [];
@@ -17,33 +72,7 @@
         'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
         })(window,document,'script','dataLayer','GTM-NWC2HDM');</script>
         <!-- End Google Tag Manager -->
-        <script type="application/ld+json">
-        {
-          "@context" : "http://schema.org",
-          "@type" : "Article",
-          "headline" : "A Report on the state of AI and its implication for the future.",
-          "name" : "State of AI Report",
-          "about" : "A Report on artificial intelligence research, talent, politics, industry, startups, safety, and China.",
-          "description" : "A Report on artificial intelligence research, talent, politics, industry, startups, safety, and China.",
-          "inLanguage" : "English",
-          "keywords" : ["State of AI Report 2022", "State of AI Report 2021", "State of AI Report 2020", "State of AI Report 2018", "State of AI Report 2019", "artificial intelligence", "deep learning", "machine learning", "reinforcement learning", "supervised learning", "startups", "venture capital", "State of AI", "State of AI Report", "State of AI Report 2018"],
-          "publisher": {
-            "@type": "Organization",
-            "name": "Air Street Capital"
-          },
-          "author" : [ {
-            "@type" : "Person",
-            "name" : "Nathan Benaich"
-          }, {
-            "@type" : "Person",
-            "name" : "Ian Hogarth"
-          } ],
-          "datePublished" : "2022-10-11",
-          "articleBody" : "We believe that AI will be a force multiplier on technological progress in our increasingly digital, data-driven world. This is because everything around us today, ranging from culture to consumer products, is a product of intelligence.\n              </P>\n              <P class=\"subtext\">\n                In this report, we set out to capture a snapshot of the exponential progress in AI with a focus on developments in the past 12 months. Consider this report as a compilation of the most interesting things we’ve seen that seeks to trigger an informed conversation about the state of AI and its implication for the future. This edition builds on the State of AI Report 2022, which can be <A href=\"https://www.stateof.ai/2022\">found here</A>.\n              </P>\n              <OL> We consider the following key dimensions in our report:\n                  <LI><STRONG>Research:</STRONG> Technology breakthroughs and their capabilities. </LI>\n                  <LI><STRONG>Talent:</STRONG> Supply, demand and concentration of talent working in the field.  </LI>\n                  <LI><STRONG>Industry:</STRONG> Large platforms, financings and areas of application for AI-driven innovation today and tomorrow. </LI>\n                  <LI><STRONG>Politics:</STRONG> Public opinion of AI, economic implications and the emerging geopolitics of AI. </LI>\n                  <LI><STRONG>Safety:</STRONG> How to ensure that highly-capable systems are aligned with our species.",
-          "url" : "https://www.stateof.ai"
-        }
-        </script>
-        <title>State of AI Report 2022</title>
+<title>State of AI Report 2022</title>
         <meta charset="utf-8">
         <meta http-equiv="x-ua-compatible" content="ie=edge">
         <meta name="author" content="Nathan Benaich and Ian Hogarth">

--- a/2023-report-launch.html
+++ b/2023-report-launch.html
@@ -1,7 +1,62 @@
 <!DOCTYPE html>
 <html class="no-js" lang="">
     <head>
-        <!-- Google tag (gtag.js) -->
+        <script type="application/ld+json">
+        {
+          "@context": "https://schema.org",
+          "@graph": [
+            {
+              "@type": "WebSite",
+              "@id": "https://www.stateof.ai/2023-report-launch#website",
+              "url": "https://www.stateof.ai/",
+              "name": "State of AI Report",
+              "publisher": {
+                "@type": "Organization",
+                "name": "Air Street Capital",
+                "url": "https://www.airstreet.com/"
+              }
+            },
+            {
+              "@type": "CreativeWorkSeries",
+              "@id": "https://www.stateof.ai/2023-report-launch#series",
+              "name": "State of AI Report",
+              "description": "The most widely read and trusted independent annual report on global progress in artificial intelligence, covering research, industry, geopolitics, and AI safety.",
+              "inLanguage": "en",
+              "startDate": "2018-01-01",
+              "url": "https://www.stateof.ai/2023-report-launch",
+              "creator": {
+                "@type": "Person",
+                "name": "Nathan Benaich",
+                "url": "https://www.nathanbenaich.com/"
+              },
+              "publisher": {
+                "@type": "Organization",
+                "name": "Air Street Capital",
+                "url": "https://www.airstreet.com/"
+              },
+              "keywords": [
+                "State of AI",
+                "State of AI Report",
+                "artificial intelligence",
+                "machine learning",
+                "deep learning",
+                "generative AI",
+                "AI research",
+                "AI industry",
+                "AI geopolitics",
+                "AI safety"
+              ],
+              "sameAs": [
+                "https://x.com/stateofai",
+                "https://www.linkedin.com/company/stateofai/",
+                "https://press.airstreet.com/",
+                "https://www.airstreet.com/"
+              ]
+            }
+          ]
+        }
+        </script>
+<!-- Google tag (gtag.js) -->
         <script async src="https://www.googletagmanager.com/gtag/js?id=G-25T8JQY0LN"></script>
         <script>
           window.dataLayer = window.dataLayer || [];
@@ -17,30 +72,7 @@
         'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
         })(window,document,'script','dataLayer','GTM-NWC2HDM');</script>
         <!-- End Google Tag Manager -->
-        <script type="application/ld+json">
-        {
-          "@context" : "http://schema.org",
-          "@type" : "Article",
-          "headline" : "A Report on the state of AI and its implication for the future.",
-          "name" : "State of AI Report",
-          "about" : "A Report on artificial intelligence research, talent, politics, industry, startups, and China.",
-          "description" : "A Report on artificial intelligence research, talent, politics, industry, startups, and China.",
-          "inLanguage" : "English",
-          "keywords" : ["State of AI Report 2023", "State of AI Report 2022", "State of AI Report 2021", "State of AI Report 2020", "State of AI Report 2018", "State of AI Report 2019", "artificial intelligence", "deep learning", "machine learning", "generative ai", "genai", "reinforcement learning", "supervised learning", "startups", "venture capital", "State of AI", "State of AI Report", "State of AI Report 2018"],
-          "publisher": {
-            "@type": "Organization",
-            "name": "Air Street Capital"
-          },
-          "author" : [ {
-            "@type" : "Person",
-            "name" : "Nathan Benaich"
-          } ],
-          "datePublished" : "2023-10-12",
-          "articleBody" : "We believe that AI will be a force multiplier on technological progress in our increasingly digital, data-driven world. This is because everything around us today, ranging from culture to consumer products, is a product of intelligence.\n              </P>\n              <P class=\"subtext\">\n                In this report, we set out to capture a snapshot of the exponential progress in AI with a focus on developments in the past 12 months. Consider this report as a compilation of the most interesting things we’ve seen that seeks to trigger an informed conversation about the state of AI and its implication for the future. This edition builds on the State of AI Report 2022, which can be <A href=\"https://www.stateof.ai/2022\">found here</A>.\n              </P>\n              <OL> We consider the following key dimensions in our report:\n                  <LI><STRONG>Research:</STRONG> Technology breakthroughs and their capabilities. </LI>\n                  <LI><STRONG>Talent:</STRONG> Supply, demand and concentration of talent working in the field.  </LI>\n                  <LI><STRONG>Industry:</STRONG> Large platforms, financings and areas of application for AI-driven innovation today and tomorrow. </LI>\n                  <LI><STRONG>Politics:</STRONG> Public opinion of AI, economic implications and the emerging geopolitics of AI. </LI>\n                  <LI><STRONG>Safety:</STRONG> How to ensure that highly-capable systems are aligned with our species.",
-          "url" : "https://www.stateof.ai"
-        }
-        </script>
-        <title>Welcome to State of AI Report 2023</title>
+<title>Welcome to State of AI Report 2023</title>
         <meta charset="utf-8">
         <meta http-equiv="x-ua-compatible" content="ie=edge">
         <meta name="author" content="Nathan Benaich and Air Street Capital">

--- a/2023.html
+++ b/2023.html
@@ -1,7 +1,62 @@
 <!DOCTYPE html>
 <html class="no-js" lang="">
     <head>
-        <!-- Google tag (gtag.js) -->
+        <script type="application/ld+json">
+        {
+          "@context": "https://schema.org",
+          "@graph": [
+            {
+              "@type": "WebSite",
+              "@id": "https://www.stateof.ai/2023#website",
+              "url": "https://www.stateof.ai/",
+              "name": "State of AI Report",
+              "publisher": {
+                "@type": "Organization",
+                "name": "Air Street Capital",
+                "url": "https://www.airstreet.com/"
+              }
+            },
+            {
+              "@type": "CreativeWorkSeries",
+              "@id": "https://www.stateof.ai/2023#series",
+              "name": "State of AI Report",
+              "description": "The most widely read and trusted independent annual report on global progress in artificial intelligence, covering research, industry, geopolitics, and AI safety.",
+              "inLanguage": "en",
+              "startDate": "2018-01-01",
+              "url": "https://www.stateof.ai/2023",
+              "creator": {
+                "@type": "Person",
+                "name": "Nathan Benaich",
+                "url": "https://www.nathanbenaich.com/"
+              },
+              "publisher": {
+                "@type": "Organization",
+                "name": "Air Street Capital",
+                "url": "https://www.airstreet.com/"
+              },
+              "keywords": [
+                "State of AI",
+                "State of AI Report",
+                "artificial intelligence",
+                "machine learning",
+                "deep learning",
+                "generative AI",
+                "AI research",
+                "AI industry",
+                "AI geopolitics",
+                "AI safety"
+              ],
+              "sameAs": [
+                "https://x.com/stateofai",
+                "https://www.linkedin.com/company/stateofai/",
+                "https://press.airstreet.com/",
+                "https://www.airstreet.com/"
+              ]
+            }
+          ]
+        }
+        </script>
+<!-- Google tag (gtag.js) -->
         <script async src="https://www.googletagmanager.com/gtag/js?id=G-25T8JQY0LN"></script>
         <script>
           window.dataLayer = window.dataLayer || [];
@@ -17,30 +72,7 @@
         'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
         })(window,document,'script','dataLayer','GTM-NWC2HDM');</script>
         <!-- End Google Tag Manager -->
-        <script type="application/ld+json">
-        {
-          "@context" : "http://schema.org",
-          "@type" : "Article",
-          "headline" : "A Report on the state of AI and its implication for the future.",
-          "name" : "State of AI Report",
-          "about" : "A Report on artificial intelligence research, talent, politics, industry, startups, and China.",
-          "description" : "A Report on artificial intelligence research, talent, politics, industry, startups, and China.",
-          "inLanguage" : "English",
-          "keywords" : ["State of AI Report 2023", "State of AI Report 2022", "State of AI Report 2021", "State of AI Report 2020", "State of AI Report 2018", "State of AI Report 2019", "artificial intelligence", "deep learning", "machine learning", "generative ai", "genai", "reinforcement learning", "supervised learning", "startups", "venture capital", "State of AI", "State of AI Report", "State of AI Report 2018"],
-          "publisher": {
-            "@type": "Organization",
-            "name": "Air Street Capital"
-          },
-          "author" : [ {
-            "@type" : "Person",
-            "name" : "Nathan Benaich"
-          } ],
-          "datePublished" : "2023-10-12",
-          "articleBody" : "We believe that AI will be a force multiplier on technological progress in our increasingly digital, data-driven world. This is because everything around us today, ranging from culture to consumer products, is a product of intelligence.\n              </P>\n              <P class=\"subtext\">\n                In this report, we set out to capture a snapshot of the exponential progress in AI with a focus on developments in the past 12 months. Consider this report as a compilation of the most interesting things we’ve seen that seeks to trigger an informed conversation about the state of AI and its implication for the future. This edition builds on the State of AI Report 2022, which can be <A href=\"https://www.stateof.ai/2022\">found here</A>.\n              </P>\n              <OL> We consider the following key dimensions in our report:\n                  <LI><STRONG>Research:</STRONG> Technology breakthroughs and their capabilities. </LI>\n                  <LI><STRONG>Talent:</STRONG> Supply, demand and concentration of talent working in the field.  </LI>\n                  <LI><STRONG>Industry:</STRONG> Large platforms, financings and areas of application for AI-driven innovation today and tomorrow. </LI>\n                  <LI><STRONG>Politics:</STRONG> Public opinion of AI, economic implications and the emerging geopolitics of AI. </LI>\n                  <LI><STRONG>Safety:</STRONG> How to ensure that highly-capable systems are aligned with our species.",
-          "url" : "https://www.stateof.ai"
-        }
-        </script>
-        <title>Welcome to State of AI Report 2023</title>
+<title>Welcome to State of AI Report 2023</title>
         <meta charset="utf-8">
         <meta http-equiv="x-ua-compatible" content="ie=edge">
         <meta name="author" content="Nathan Benaich and Air Street Capital">

--- a/2024-report-launch.html
+++ b/2024-report-launch.html
@@ -1,7 +1,62 @@
 <!DOCTYPE html>
 <html class="no-js" lang="">
     <head>
-        <!-- Google tag (gtag.js) -->
+        <script type="application/ld+json">
+        {
+          "@context": "https://schema.org",
+          "@graph": [
+            {
+              "@type": "WebSite",
+              "@id": "https://www.stateof.ai/2024-report-launch#website",
+              "url": "https://www.stateof.ai/",
+              "name": "State of AI Report",
+              "publisher": {
+                "@type": "Organization",
+                "name": "Air Street Capital",
+                "url": "https://www.airstreet.com/"
+              }
+            },
+            {
+              "@type": "CreativeWorkSeries",
+              "@id": "https://www.stateof.ai/2024-report-launch#series",
+              "name": "State of AI Report",
+              "description": "The most widely read and trusted independent annual report on global progress in artificial intelligence, covering research, industry, geopolitics, and AI safety.",
+              "inLanguage": "en",
+              "startDate": "2018-01-01",
+              "url": "https://www.stateof.ai/2024-report-launch",
+              "creator": {
+                "@type": "Person",
+                "name": "Nathan Benaich",
+                "url": "https://www.nathanbenaich.com/"
+              },
+              "publisher": {
+                "@type": "Organization",
+                "name": "Air Street Capital",
+                "url": "https://www.airstreet.com/"
+              },
+              "keywords": [
+                "State of AI",
+                "State of AI Report",
+                "artificial intelligence",
+                "machine learning",
+                "deep learning",
+                "generative AI",
+                "AI research",
+                "AI industry",
+                "AI geopolitics",
+                "AI safety"
+              ],
+              "sameAs": [
+                "https://x.com/stateofai",
+                "https://www.linkedin.com/company/stateofai/",
+                "https://press.airstreet.com/",
+                "https://www.airstreet.com/"
+              ]
+            }
+          ]
+        }
+        </script>
+<!-- Google tag (gtag.js) -->
         <script async src="https://www.googletagmanager.com/gtag/js?id=G-25T8JQY0LN"></script>
         <script>
           window.dataLayer = window.dataLayer || [];
@@ -17,30 +72,7 @@
         'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
         })(window,document,'script','dataLayer','GTM-NWC2HDM');</script>
         <!-- End Google Tag Manager -->
-        <script type="application/ld+json">
-        {
-          "@context" : "http://schema.org",
-          "@type" : "Article",
-          "headline" : "A Report on the state of AI and its implication for the future.",
-          "name" : "State of AI Report",
-          "about" : "A Report on artificial intelligence research, talent, politics, industry, safety, startups, and China.",
-          "description" : "A Report on artificial intelligence research, talent, politics, industry, safety, startups, and China.",
-          "inLanguage" : "English",
-          "keywords" : ["State of AI Report 2024", "State of AI Report 2023", "State of AI Report 2022", "State of AI Report 2021", "State of AI Report 2020", "State of AI Report 2018", "State of AI Report 2019", "artificial intelligence", "deep learning", "machine learning", "generative ai", "genai", "reinforcement learning", "supervised learning", "startups", "venture capital", "State of AI", "State of AI Report", "State of AI Report 2018"],
-          "publisher": {
-            "@type": "Organization",
-            "name": "Air Street Capital"
-          },
-          "author" : [ {
-            "@type" : "Person",
-            "name" : "Nathan Benaich"
-          } ],
-          "datePublished" : "2024-10-10",
-          "articleBody" : "We believe that AI will be a force multiplier on technological progress in our increasingly digital, data-driven world. This is because everything around us today, ranging from culture to consumer products, is a product of intelligence.\n              </P>\n              <P class=\"subtext\">\n                In this report, we set out to capture a snapshot of the exponential progress in AI with a focus on developments in the past 12 months. Consider this report as a compilation of the most interesting things we’ve seen that seeks to trigger an informed conversation about the state of AI and its implication for the future. This edition builds on the State of AI Report 2023, which can be <A href=\"https://www.stateof.ai/2023\">found here</A>.\n              </P>\n              <OL> We consider the following key dimensions in our report:\n                  <LI><STRONG>Research:</STRONG> Technology breakthroughs and their capabilities. </LI>\n                  <LI><STRONG>Talent:</STRONG> Supply, demand and concentration of talent working in the field.  </LI>\n                  <LI><STRONG>Industry:</STRONG> Large platforms, financings and areas of application for AI-driven innovation today and tomorrow. </LI>\n                  <LI><STRONG>Politics:</STRONG> Public opinion of AI, economic implications and the emerging geopolitics of AI. </LI>\n                  <LI><STRONG>Safety:</STRONG> How to ensure that highly-capable systems are aligned with our species.",
-          "url" : "https://www.stateof.ai"
-        }
-        </script>
-        <title>Welcome to State of AI Report 2024</title>
+<title>Welcome to State of AI Report 2024</title>
         <meta charset="utf-8">
         <meta http-equiv="x-ua-compatible" content="ie=edge">
         <meta name="author" content="Nathan Benaich and Air Street Capital">

--- a/2024.html
+++ b/2024.html
@@ -1,7 +1,62 @@
 <!DOCTYPE html>
 <html class="no-js" lang="">
     <head>
-        <!-- Google tag (gtag.js) -->
+        <script type="application/ld+json">
+        {
+          "@context": "https://schema.org",
+          "@graph": [
+            {
+              "@type": "WebSite",
+              "@id": "https://www.stateof.ai/2024#website",
+              "url": "https://www.stateof.ai/",
+              "name": "State of AI Report",
+              "publisher": {
+                "@type": "Organization",
+                "name": "Air Street Capital",
+                "url": "https://www.airstreet.com/"
+              }
+            },
+            {
+              "@type": "CreativeWorkSeries",
+              "@id": "https://www.stateof.ai/2024#series",
+              "name": "State of AI Report",
+              "description": "The most widely read and trusted independent annual report on global progress in artificial intelligence, covering research, industry, geopolitics, and AI safety.",
+              "inLanguage": "en",
+              "startDate": "2018-01-01",
+              "url": "https://www.stateof.ai/2024",
+              "creator": {
+                "@type": "Person",
+                "name": "Nathan Benaich",
+                "url": "https://www.nathanbenaich.com/"
+              },
+              "publisher": {
+                "@type": "Organization",
+                "name": "Air Street Capital",
+                "url": "https://www.airstreet.com/"
+              },
+              "keywords": [
+                "State of AI",
+                "State of AI Report",
+                "artificial intelligence",
+                "machine learning",
+                "deep learning",
+                "generative AI",
+                "AI research",
+                "AI industry",
+                "AI geopolitics",
+                "AI safety"
+              ],
+              "sameAs": [
+                "https://x.com/stateofai",
+                "https://www.linkedin.com/company/stateofai/",
+                "https://press.airstreet.com/",
+                "https://www.airstreet.com/"
+              ]
+            }
+          ]
+        }
+        </script>
+<!-- Google tag (gtag.js) -->
         <script async src="https://www.googletagmanager.com/gtag/js?id=G-25T8JQY0LN"></script>
         <script>
           window.dataLayer = window.dataLayer || [];
@@ -17,30 +72,7 @@
         'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
         })(window,document,'script','dataLayer','GTM-NWC2HDM');</script>
         <!-- End Google Tag Manager -->
-        <script type="application/ld+json">
-        {
-          "@context" : "http://schema.org",
-          "@type" : "Article",
-          "headline" : "A Report on the state of AI and its implication for the future.",
-          "name" : "State of AI Report",
-          "about" : "A Report on artificial intelligence research, talent, politics, industry, safety, startups, and China.",
-          "description" : "A Report on artificial intelligence research, talent, politics, industry, safety, startups, and China.",
-          "inLanguage" : "English",
-          "keywords" : ["State of AI Report 2024", "State of AI Report 2023", "State of AI Report 2022", "State of AI Report 2021", "State of AI Report 2020", "State of AI Report 2018", "State of AI Report 2019", "artificial intelligence", "deep learning", "machine learning", "generative ai", "genai", "reinforcement learning", "supervised learning", "startups", "venture capital", "State of AI", "State of AI Report", "State of AI Report 2018"],
-          "publisher": {
-            "@type": "Organization",
-            "name": "Air Street Capital"
-          },
-          "author" : [ {
-            "@type" : "Person",
-            "name" : "Nathan Benaich"
-          } ],
-          "datePublished" : "2024-10-10",
-          "articleBody" : "We believe that AI will be a force multiplier on technological progress in our increasingly digital, data-driven world. This is because everything around us today, ranging from culture to consumer products, is a product of intelligence.\n              </P>\n              <P class=\"subtext\">\n                In this report, we set out to capture a snapshot of the exponential progress in AI with a focus on developments in the past 12 months. Consider this report as a compilation of the most interesting things we’ve seen that seeks to trigger an informed conversation about the state of AI and its implication for the future. This edition builds on the State of AI Report 2023, which can be <A href=\"https://www.stateof.ai/2023\">found here</A>.\n              </P>\n              <OL> We consider the following key dimensions in our report:\n                  <LI><STRONG>Research:</STRONG> Technology breakthroughs and their capabilities. </LI>\n                  <LI><STRONG>Talent:</STRONG> Supply, demand and concentration of talent working in the field.  </LI>\n                  <LI><STRONG>Industry:</STRONG> Large platforms, financings and areas of application for AI-driven innovation today and tomorrow. </LI>\n                  <LI><STRONG>Politics:</STRONG> Public opinion of AI, economic implications and the emerging geopolitics of AI. </LI>\n                  <LI><STRONG>Safety:</STRONG> How to ensure that highly-capable systems are aligned with our species.",
-          "url" : "https://www.stateof.ai"
-        }
-        </script>
-        <title>Welcome to State of AI Report 2024</title>
+<title>Welcome to State of AI Report 2024</title>
         <meta charset="utf-8">
         <meta http-equiv="x-ua-compatible" content="ie=edge">
         <meta name="author" content="Nathan Benaich and Air Street Capital">

--- a/2025-report-launch.html
+++ b/2025-report-launch.html
@@ -1,7 +1,62 @@
 <!DOCTYPE html>
 <html class="no-js" lang="">
     <head>
-        <!-- Google tag (gtag.js) -->
+        <script type="application/ld+json">
+        {
+          "@context": "https://schema.org",
+          "@graph": [
+            {
+              "@type": "WebSite",
+              "@id": "https://www.stateof.ai/2025-report-launch#website",
+              "url": "https://www.stateof.ai/",
+              "name": "State of AI Report",
+              "publisher": {
+                "@type": "Organization",
+                "name": "Air Street Capital",
+                "url": "https://www.airstreet.com/"
+              }
+            },
+            {
+              "@type": "CreativeWorkSeries",
+              "@id": "https://www.stateof.ai/2025-report-launch#series",
+              "name": "State of AI Report",
+              "description": "The most widely read and trusted independent annual report on global progress in artificial intelligence, covering research, industry, geopolitics, and AI safety.",
+              "inLanguage": "en",
+              "startDate": "2018-01-01",
+              "url": "https://www.stateof.ai/2025-report-launch",
+              "creator": {
+                "@type": "Person",
+                "name": "Nathan Benaich",
+                "url": "https://www.nathanbenaich.com/"
+              },
+              "publisher": {
+                "@type": "Organization",
+                "name": "Air Street Capital",
+                "url": "https://www.airstreet.com/"
+              },
+              "keywords": [
+                "State of AI",
+                "State of AI Report",
+                "artificial intelligence",
+                "machine learning",
+                "deep learning",
+                "generative AI",
+                "AI research",
+                "AI industry",
+                "AI geopolitics",
+                "AI safety"
+              ],
+              "sameAs": [
+                "https://x.com/stateofai",
+                "https://www.linkedin.com/company/stateofai/",
+                "https://press.airstreet.com/",
+                "https://www.airstreet.com/"
+              ]
+            }
+          ]
+        }
+        </script>
+<!-- Google tag (gtag.js) -->
         <script async src="https://www.googletagmanager.com/gtag/js?id=G-25T8JQY0LN"></script>
         <script>
           window.dataLayer = window.dataLayer || [];
@@ -17,30 +72,7 @@
         'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
         })(window,document,'script','dataLayer','GTM-NWC2HDM');</script>
         <!-- End Google Tag Manager -->
-        <script type="application/ld+json">
-        {
-          "@context" : "http://schema.org",
-          "@type" : "Article",
-          "headline" : "A Report on the state of AI and its implication for the future.",
-          "name" : "State of AI Report",
-          "about" : "A Report on artificial intelligence research, talent, politics, industry, safety, startups, and China.",
-          "description" : "A Report on artificial intelligence research, talent, politics, industry, safety, startups, and China.",
-          "inLanguage" : "English",
-          "keywords" : ["State of AI Report 2025", "State of AI Report 2024", "State of AI Report 2023", "State of AI Report 2022", "State of AI Report 2021", "State of AI Report 2020", "State of AI Report 2018", "State of AI Report 2019", "artificial intelligence", "deep learning", "machine learning", "generative ai", "genai", "reinforcement learning", "supervised learning", "startups", "venture capital", "State of AI", "State of AI Report", "State of AI Report 2018"],
-          "publisher": {
-            "@type": "Organization",
-            "name": "Air Street Capital"
-          },
-          "author" : [ {
-            "@type" : "Person",
-            "name" : "Nathan Benaich"
-          } ],
-          "datePublished" : "2025-10-09",
-          "articleBody" : "We believe that AI will be a force multiplier on technological progress in our increasingly digital, data-driven world. This is because everything around us today, ranging from culture to consumer products, is a product of intelligence.\n              </P>\n              <P class=\"subtext\">\n                In this report, we set out to capture a snapshot of the exponential progress in AI with a focus on developments in the past 12 months. Consider this report as a compilation of the most interesting things we’ve seen that seeks to trigger an informed conversation about the state of AI and its implication for the future. This edition builds on the State of AI Report 2024, which can be <A href=\"https://www.stateof.ai/2023\">found here</A>.\n              </P>\n              <OL> We consider the following key dimensions in our report:\n                  <LI><STRONG>Research:</STRONG> Technology breakthroughs and their capabilities. </LI>\n                  <LI><STRONG>Talent:</STRONG> Supply, demand and concentration of talent working in the field.  </LI>\n                  <LI><STRONG>Industry:</STRONG> Large platforms, financings and areas of application for AI-driven innovation today and tomorrow. </LI>\n                  <LI><STRONG>Politics:</STRONG> Public opinion of AI, economic implications and the emerging geopolitics of AI. </LI>\n                  <LI><STRONG>Safety:</STRONG> How to ensure that highly-capable systems are aligned with our species.",
-          "url" : "https://www.stateof.ai"
-        }
-        </script>
-        <title>Welcome to State of AI Report 2025</title>
+<title>Welcome to State of AI Report 2025</title>
         <meta charset="utf-8">
         <meta http-equiv="x-ua-compatible" content="ie=edge">
         <meta name="author" content="Nathan Benaich and Air Street Capital">

--- a/2025-staging.html
+++ b/2025-staging.html
@@ -1,7 +1,62 @@
 <!DOCTYPE html>
 <html class="no-js" lang="">
     <head>
-        <!-- Google tag (gtag.js) -->
+        <script type="application/ld+json">
+        {
+          "@context": "https://schema.org",
+          "@graph": [
+            {
+              "@type": "WebSite",
+              "@id": "https://www.stateof.ai/2025-staging#website",
+              "url": "https://www.stateof.ai/",
+              "name": "State of AI Report",
+              "publisher": {
+                "@type": "Organization",
+                "name": "Air Street Capital",
+                "url": "https://www.airstreet.com/"
+              }
+            },
+            {
+              "@type": "CreativeWorkSeries",
+              "@id": "https://www.stateof.ai/2025-staging#series",
+              "name": "State of AI Report",
+              "description": "The most widely read and trusted independent annual report on global progress in artificial intelligence, covering research, industry, geopolitics, and AI safety.",
+              "inLanguage": "en",
+              "startDate": "2018-01-01",
+              "url": "https://www.stateof.ai/2025-staging",
+              "creator": {
+                "@type": "Person",
+                "name": "Nathan Benaich",
+                "url": "https://www.nathanbenaich.com/"
+              },
+              "publisher": {
+                "@type": "Organization",
+                "name": "Air Street Capital",
+                "url": "https://www.airstreet.com/"
+              },
+              "keywords": [
+                "State of AI",
+                "State of AI Report",
+                "artificial intelligence",
+                "machine learning",
+                "deep learning",
+                "generative AI",
+                "AI research",
+                "AI industry",
+                "AI geopolitics",
+                "AI safety"
+              ],
+              "sameAs": [
+                "https://x.com/stateofai",
+                "https://www.linkedin.com/company/stateofai/",
+                "https://press.airstreet.com/",
+                "https://www.airstreet.com/"
+              ]
+            }
+          ]
+        }
+        </script>
+<!-- Google tag (gtag.js) -->
         <script async src="https://www.googletagmanager.com/gtag/js?id=G-25T8JQY0LN"></script>
         <script>
           window.dataLayer = window.dataLayer || [];
@@ -17,30 +72,7 @@
         'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
         })(window,document,'script','dataLayer','GTM-NWC2HDM');</script>
         <!-- End Google Tag Manager -->
-        <script type="application/ld+json">
-        {
-          "@context" : "http://schema.org",
-          "@type" : "Article",
-          "headline" : "A Report on the state of AI and its implication for the future.",
-          "name" : "State of AI Report",
-          "about" : "A Report on artificial intelligence research, talent, politics, industry, safety, startups, and China.",
-          "description" : "A Report on artificial intelligence research, talent, politics, industry, safety, startups, and China.",
-          "inLanguage" : "English",
-          "keywords" : ["State of AI Report 2025", "State of AI Report 2024", "State of AI Report 2023", "State of AI Report 2022", "State of AI Report 2021", "State of AI Report 2020", "State of AI Report 2018", "State of AI Report 2019", "artificial intelligence", "deep learning", "machine learning", "generative ai", "genai", "reinforcement learning", "supervised learning", "startups", "venture capital", "State of AI", "State of AI Report", "State of AI Report 2018"],
-          "publisher": {
-            "@type": "Organization",
-            "name": "Air Street Capital"
-          },
-          "author" : [ {
-            "@type" : "Person",
-            "name" : "Nathan Benaich"
-          } ],
-          "datePublished" : "2025-10-09",
-          "articleBody" : "We believe that AI will be a force multiplier on technological progress in our increasingly digital, data-driven world. This is because everything around us today, ranging from culture to consumer products, is a product of intelligence.\n              </P>\n              <P class=\"subtext\">\n                In this report, we set out to capture a snapshot of the exponential progress in AI with a focus on developments in the past 12 months. Consider this report as a compilation of the most interesting things we’ve seen that seeks to trigger an informed conversation about the state of AI and its implication for the future. This edition builds on the State of AI Report 2024, which can be <A href=\"https://www.stateof.ai/2023\">found here</A>.\n              </P>\n              <OL> We consider the following key dimensions in our report:\n                  <LI><STRONG>Research:</STRONG> Technology breakthroughs and their capabilities. </LI>\n                  <LI><STRONG>Talent:</STRONG> Supply, demand and concentration of talent working in the field.  </LI>\n                  <LI><STRONG>Industry:</STRONG> Large platforms, financings and areas of application for AI-driven innovation today and tomorrow. </LI>\n                  <LI><STRONG>Politics:</STRONG> Public opinion of AI, economic implications and the emerging geopolitics of AI. </LI>\n                  <LI><STRONG>Safety:</STRONG> How to ensure that highly-capable systems are aligned with our species.",
-          "url" : "https://www.stateof.ai"
-        }
-        </script>
-        <title>Welcome to State of AI Report 2025</title>
+<title>Welcome to State of AI Report 2025</title>
         <meta charset="utf-8">
         <meta http-equiv="x-ua-compatible" content="ie=edge">
         <meta name="author" content="Nathan Benaich and Air Street Capital">

--- a/DEPRACATEDcompute.html
+++ b/DEPRACATEDcompute.html
@@ -1,7 +1,62 @@
 <!DOCTYPE html>
 <html class="no-js" lang="">
     <head>
-        <!-- Google tag (gtag.js) -->
+        <script type="application/ld+json">
+        {
+          "@context": "https://schema.org",
+          "@graph": [
+            {
+              "@type": "WebSite",
+              "@id": "https://www.stateof.ai/DEPRACATEDcompute#website",
+              "url": "https://www.stateof.ai/",
+              "name": "State of AI Report",
+              "publisher": {
+                "@type": "Organization",
+                "name": "Air Street Capital",
+                "url": "https://www.airstreet.com/"
+              }
+            },
+            {
+              "@type": "CreativeWorkSeries",
+              "@id": "https://www.stateof.ai/DEPRACATEDcompute#series",
+              "name": "State of AI Report",
+              "description": "The most widely read and trusted independent annual report on global progress in artificial intelligence, covering research, industry, geopolitics, and AI safety.",
+              "inLanguage": "en",
+              "startDate": "2018-01-01",
+              "url": "https://www.stateof.ai/DEPRACATEDcompute",
+              "creator": {
+                "@type": "Person",
+                "name": "Nathan Benaich",
+                "url": "https://www.nathanbenaich.com/"
+              },
+              "publisher": {
+                "@type": "Organization",
+                "name": "Air Street Capital",
+                "url": "https://www.airstreet.com/"
+              },
+              "keywords": [
+                "State of AI",
+                "State of AI Report",
+                "artificial intelligence",
+                "machine learning",
+                "deep learning",
+                "generative AI",
+                "AI research",
+                "AI industry",
+                "AI geopolitics",
+                "AI safety"
+              ],
+              "sameAs": [
+                "https://x.com/stateofai",
+                "https://www.linkedin.com/company/stateofai/",
+                "https://press.airstreet.com/",
+                "https://www.airstreet.com/"
+              ]
+            }
+          ]
+        }
+        </script>
+<!-- Google tag (gtag.js) -->
         <script async src="https://www.googletagmanager.com/gtag/js?id=G-25T8JQY0LN"></script>
         <script>
           window.dataLayer = window.dataLayer || [];
@@ -17,33 +72,7 @@
         'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
         })(window,document,'script','dataLayer','GTM-NWC2HDM');</script>
         <!-- End Google Tag Manager -->
-        <script type="application/ld+json">
-        {
-          "@context" : "http://schema.org",
-          "@type" : "Article",
-          "headline" : "A Report on the state of AI and its implication for the future.",
-          "name" : "State of AI Report",
-          "about" : "A Report on artificial intelligence research, talent, politics, industry, startups, safety, and China.",
-          "description" : "A Report on artificial intelligence research, talent, politics, industry, startups, safety, and China.",
-          "inLanguage" : "English",
-          "keywords" : ["State of AI Report 2022", "State of AI Report 2021", "State of AI Report 2020", "State of AI Report 2018", "State of AI Report 2019", "artificial intelligence", "deep learning", "machine learning", "reinforcement learning", "supervised learning", "startups", "venture capital", "State of AI", "State of AI Report", "State of AI Report 2018"],
-          "publisher": {
-            "@type": "Organization",
-            "name": "Air Street Capital"
-          },
-          "author" : [ {
-            "@type" : "Person",
-            "name" : "Nathan Benaich"
-          }, {
-            "@type" : "Person",
-            "name" : "Ian Hogarth"
-          } ],
-          "datePublished" : "2022-10-11",
-          "articleBody" : "We believe that AI will be a force multiplier on technological progress in our increasingly digital, data-driven world. This is because everything around us today, ranging from culture to consumer products, is a product of intelligence.\n              </P>\n              <P class=\"subtext\">\n                In this report, we set out to capture a snapshot of the exponential progress in AI with a focus on developments in the past 12 months. Consider this report as a compilation of the most interesting things we’ve seen that seeks to trigger an informed conversation about the state of AI and its implication for the future. This edition builds on the State of AI Report 2022, which can be <A href=\"https://www.stateof.ai/2022\">found here</A>.\n              </P>\n              <OL> We consider the following key dimensions in our report:\n                  <LI><STRONG>Research:</STRONG> Technology breakthroughs and their capabilities. </LI>\n                  <LI><STRONG>Talent:</STRONG> Supply, demand and concentration of talent working in the field.  </LI>\n                  <LI><STRONG>Industry:</STRONG> Large platforms, financings and areas of application for AI-driven innovation today and tomorrow. </LI>\n                  <LI><STRONG>Politics:</STRONG> Public opinion of AI, economic implications and the emerging geopolitics of AI. </LI>\n                  <LI><STRONG>Safety:</STRONG> How to ensure that highly-capable systems are aligned with our species.",
-          "url" : "https://www.stateof.ai"
-        }
-        </script>
-        <title>State of AI Report Compute Index</title>
+<title>State of AI Report Compute Index</title>
         <meta charset="utf-8">
         <meta http-equiv="x-ua-compatible" content="ie=edge">
         <meta name="author" content="Nathan Benaich and Ian Hogarth">

--- a/about.html
+++ b/about.html
@@ -1,7 +1,62 @@
 <!DOCTYPE html>
 <html class="no-js" lang="en">
 <head>
-        <!-- Google tag (gtag.js) -->
+        <script type="application/ld+json">
+        {
+          "@context": "https://schema.org",
+          "@graph": [
+            {
+              "@type": "WebSite",
+              "@id": "https://www.stateof.ai/about#website",
+              "url": "https://www.stateof.ai/",
+              "name": "State of AI Report",
+              "publisher": {
+                "@type": "Organization",
+                "name": "Air Street Capital",
+                "url": "https://www.airstreet.com/"
+              }
+            },
+            {
+              "@type": "CreativeWorkSeries",
+              "@id": "https://www.stateof.ai/about#series",
+              "name": "State of AI Report",
+              "description": "The most widely read and trusted independent annual report on global progress in artificial intelligence, covering research, industry, geopolitics, and AI safety.",
+              "inLanguage": "en",
+              "startDate": "2018-01-01",
+              "url": "https://www.stateof.ai/about",
+              "creator": {
+                "@type": "Person",
+                "name": "Nathan Benaich",
+                "url": "https://www.nathanbenaich.com/"
+              },
+              "publisher": {
+                "@type": "Organization",
+                "name": "Air Street Capital",
+                "url": "https://www.airstreet.com/"
+              },
+              "keywords": [
+                "State of AI",
+                "State of AI Report",
+                "artificial intelligence",
+                "machine learning",
+                "deep learning",
+                "generative AI",
+                "AI research",
+                "AI industry",
+                "AI geopolitics",
+                "AI safety"
+              ],
+              "sameAs": [
+                "https://x.com/stateofai",
+                "https://www.linkedin.com/company/stateofai/",
+                "https://press.airstreet.com/",
+                "https://www.airstreet.com/"
+              ]
+            }
+          ]
+        }
+        </script>
+<!-- Google tag (gtag.js) -->
         <script async src="https://www.googletagmanager.com/gtag/js?id=G-25T8JQY0LN"></script>
         <script>
           window.dataLayer = window.dataLayer || [];
@@ -41,26 +96,7 @@
         <meta name="twitter:image" content="https://www.stateof.ai/2025-report-live.png" />
 
         <!-- Schema.org entity definition -->
-        <script type="application/ld+json">
-        {
-          "@context": "https://schema.org",
-          "@type": "CreativeWorkSeries",
-          "name": "The State of AI Report",
-          "description": "An independent, annual report on global progress in artificial intelligence, covering research, industry, geopolitics, and safety.",
-          "startDate": "2018-01-01",
-          "publisher": {
-            "@type": "Organization",
-            "name": "State of AI"
-          },
-          "author": {
-            "@type": "Person",
-            "name": "Nathan Benaich"
-          },
-          "url": "https://www.stateof.ai"
-        }
-        </script>
-
-        <link rel="manifest" href="site.webmanifest">
+<link rel="manifest" href="site.webmanifest">
         <link rel="icon" href="favicon.ico" type="image/x-icon"/>
         <link rel="shortcut icon" href="favicon.ico" type="image/x-icon"/>
         <link href="https://fonts.googleapis.com/css?family=PT+Sans:400,700" rel="stylesheet">

--- a/compute.html
+++ b/compute.html
@@ -1,7 +1,62 @@
 <!DOCTYPE html>
 <html class="no-js" lang="">
     <head>
-        <!-- Google tag (gtag.js) -->
+        <script type="application/ld+json">
+        {
+          "@context": "https://schema.org",
+          "@graph": [
+            {
+              "@type": "WebSite",
+              "@id": "https://www.stateof.ai/compute#website",
+              "url": "https://www.stateof.ai/",
+              "name": "State of AI Report",
+              "publisher": {
+                "@type": "Organization",
+                "name": "Air Street Capital",
+                "url": "https://www.airstreet.com/"
+              }
+            },
+            {
+              "@type": "CreativeWorkSeries",
+              "@id": "https://www.stateof.ai/compute#series",
+              "name": "State of AI Report",
+              "description": "The most widely read and trusted independent annual report on global progress in artificial intelligence, covering research, industry, geopolitics, and AI safety.",
+              "inLanguage": "en",
+              "startDate": "2018-01-01",
+              "url": "https://www.stateof.ai/compute",
+              "creator": {
+                "@type": "Person",
+                "name": "Nathan Benaich",
+                "url": "https://www.nathanbenaich.com/"
+              },
+              "publisher": {
+                "@type": "Organization",
+                "name": "Air Street Capital",
+                "url": "https://www.airstreet.com/"
+              },
+              "keywords": [
+                "State of AI",
+                "State of AI Report",
+                "artificial intelligence",
+                "machine learning",
+                "deep learning",
+                "generative AI",
+                "AI research",
+                "AI industry",
+                "AI geopolitics",
+                "AI safety"
+              ],
+              "sameAs": [
+                "https://x.com/stateofai",
+                "https://www.linkedin.com/company/stateofai/",
+                "https://press.airstreet.com/",
+                "https://www.airstreet.com/"
+              ]
+            }
+          ]
+        }
+        </script>
+<!-- Google tag (gtag.js) -->
         <script async src="https://www.googletagmanager.com/gtag/js?id=G-25T8JQY0LN"></script>
         <script>
           window.dataLayer = window.dataLayer || [];
@@ -17,30 +72,7 @@
         'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
         })(window,document,'script','dataLayer','GTM-NWC2HDM');</script>
         <!-- End Google Tag Manager -->
-        <script type="application/ld+json">
-        {
-          "@context" : "http://schema.org",
-          "@type" : "Article",
-          "headline" : "The definitive report on the state of AI.",
-          "name" : "State of AI Report",
-          "about" : "A Report on artificial intelligence research, talent, politics, industry, startups, safety, and China.",
-          "description" : "A Report on artificial intelligence research, talent, politics, industry, startups, safety, and China.",
-          "inLanguage" : "English",
-          "keywords" : ["State of AI Report 2025", "State of AI Report 2024", "State of AI Report 2023", "State of AI Report 2022", "State of AI Report 2021", "State of AI Report 2020", "State of AI Report 2018", "State of AI Report 2019", "artificial intelligence", "deep learning", "machine learning", "reinforcement learning", "supervised learning", "startups", "venture capital", "State of AI", "State of AI Report", "State of AI Report 2018"],
-          "publisher": {
-            "@type": "Organization",
-            "name": "Air Street Capital"
-          },
-          "author" : [ {
-            "@type" : "Person",
-            "name" : "Nathan Benaich"
-          } ],
-          "datePublished" : "2025-06-30",
-          "articleBody" : "We believe that AI will be a force multiplier on technological progress in our increasingly digital, data-driven world. This is because everything around us today, ranging from culture to consumer products, is a product of intelligence.\n              </P>\n              <P class=\"subtext\">\n                In this report, we set out to capture a snapshot of the exponential progress in AI with a focus on developments in the past 12 months. Consider this report as a compilation of the most interesting things we’ve seen that seeks to trigger an informed conversation about the state of AI and its implication for the future. This edition builds on the State of AI Report 2024, which can be <A href=\"https://www.stateof.ai/2024\">found here</A>.\n              </P>\n              <OL> We consider the following key dimensions in our report:\n                  <LI><STRONG>Research:</STRONG> Technology breakthroughs and their capabilities. </LI>\n                  <LI><STRONG>Talent:</STRONG> Supply, demand and concentration of talent working in the field.  </LI>\n                  <LI><STRONG>Industry:</STRONG> Large platforms, financings and areas of application for AI-driven innovation today and tomorrow. </LI>\n                  <LI><STRONG>Politics:</STRONG> Public opinion of AI, economic implications and the emerging geopolitics of AI. </LI>\n                  <LI><STRONG>Safety:</STRONG> How to ensure that highly-capable systems are aligned with our species.",
-          "url" : "https://www.stateof.ai"
-        }
-        </script>
-        <title>State of AI Report Compute Index</title>
+<title>State of AI Report Compute Index</title>
         <meta charset="utf-8">
         <meta http-equiv="x-ua-compatible" content="ie=edge">
         <meta name="author" content="Nathan Benaich and Ian Hogarth">

--- a/index-10oct2022.html
+++ b/index-10oct2022.html
@@ -1,7 +1,62 @@
 <!DOCTYPE html>
 <html class="no-js" lang="">
     <head>
-        <!-- Google tag (gtag.js) -->
+        <script type="application/ld+json">
+        {
+          "@context": "https://schema.org",
+          "@graph": [
+            {
+              "@type": "WebSite",
+              "@id": "https://www.stateof.ai/index-10oct2022#website",
+              "url": "https://www.stateof.ai/",
+              "name": "State of AI Report",
+              "publisher": {
+                "@type": "Organization",
+                "name": "Air Street Capital",
+                "url": "https://www.airstreet.com/"
+              }
+            },
+            {
+              "@type": "CreativeWorkSeries",
+              "@id": "https://www.stateof.ai/index-10oct2022#series",
+              "name": "State of AI Report",
+              "description": "The most widely read and trusted independent annual report on global progress in artificial intelligence, covering research, industry, geopolitics, and AI safety.",
+              "inLanguage": "en",
+              "startDate": "2018-01-01",
+              "url": "https://www.stateof.ai/index-10oct2022",
+              "creator": {
+                "@type": "Person",
+                "name": "Nathan Benaich",
+                "url": "https://www.nathanbenaich.com/"
+              },
+              "publisher": {
+                "@type": "Organization",
+                "name": "Air Street Capital",
+                "url": "https://www.airstreet.com/"
+              },
+              "keywords": [
+                "State of AI",
+                "State of AI Report",
+                "artificial intelligence",
+                "machine learning",
+                "deep learning",
+                "generative AI",
+                "AI research",
+                "AI industry",
+                "AI geopolitics",
+                "AI safety"
+              ],
+              "sameAs": [
+                "https://x.com/stateofai",
+                "https://www.linkedin.com/company/stateofai/",
+                "https://press.airstreet.com/",
+                "https://www.airstreet.com/"
+              ]
+            }
+          ]
+        }
+        </script>
+<!-- Google tag (gtag.js) -->
         <script async src="https://www.googletagmanager.com/gtag/js?id=G-25T8JQY0LN"></script>
         <script>
           window.dataLayer = window.dataLayer || [];
@@ -17,33 +72,7 @@
         'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
         })(window,document,'script','dataLayer','GTM-NWC2HDM');</script>
         <!-- End Google Tag Manager -->
-        <script type="application/ld+json">
-        {
-          "@context" : "http://schema.org",
-          "@type" : "Article",
-          "headline" : "A Report on the state of AI and its implication for the future.",
-          "name" : "State of AI Report",
-          "about" : "A Report on artificial intelligence research, talent, politics, industry, startups, and China.",
-          "description" : "A Report on artificial intelligence research, talent, politics, industry, startups, and China.",
-          "inLanguage" : "English",
-          "keywords" : ["State of AI Report 2022", "State of AI Report 2021", "State of AI Report 2020", "State of AI Report 2018", "State of AI Report 2019", "artificial intelligence", "deep learning", "machine learning", "reinforcement learning", "supervised learning", "startups", "venture capital", "State of AI", "State of AI Report", "State of AI Report 2018"],
-          "publisher": {
-            "@type": "Organization",
-            "name": "Air Street Capital"
-          },
-          "author" : [ {
-            "@type" : "Person",
-            "name" : "Nathan Benaich"
-          }, {
-            "@type" : "Person",
-            "name" : "Ian Hogarth"
-          } ],
-          "datePublished" : "2022-10-11",
-          "articleBody" : "We believe that AI will be a force multiplier on technological progress in our increasingly digital, data-driven world. This is because everything around us today, ranging from culture to consumer products, is a product of intelligence.\n              </P>\n              <P class=\"subtext\">\n                In this report, we set out to capture a snapshot of the exponential progress in AI with a focus on developments in the past 12 months. Consider this report as a compilation of the most interesting things we’ve seen that seeks to trigger an informed conversation about the state of AI and its implication for the future. This edition builds on the State of AI Report 2021, which can be <A href=\"https://www.stateof.ai/2021\">found here</A>.\n              </P>\n              <OL> We consider the following key dimensions in our report:\n                  <LI><STRONG>Research:</STRONG> Technology breakthroughs and their capabilities. </LI>\n                  <LI><STRONG>Talent:</STRONG> Supply, demand and concentration of talent working in the field.  </LI>\n                  <LI><STRONG>Industry:</STRONG> Large platforms, financings and areas of application for AI-driven innovation today and tomorrow. </LI>\n                  <LI><STRONG>Politics:</STRONG> Public opinion of AI, economic implications and the emerging geopolitics of AI. </LI>\n                  <LI><STRONG>Safety:</STRONG> How to ensure that highly-capable systems are aligned with our species.",
-          "url" : "https://www.stateof.ai"
-        }
-        </script>
-        <title>State of AI Report 2022</title>
+<title>State of AI Report 2022</title>
         <meta charset="utf-8">
         <meta http-equiv="x-ua-compatible" content="ie=edge">
         <meta name="author" content="Nathan Benaich and Ian Hogarth">

--- a/index-11-oct-2021.html
+++ b/index-11-oct-2021.html
@@ -1,7 +1,62 @@
 <!DOCTYPE html>
 <html class="no-js" lang="">
     <head>
-        <!-- Google tag (gtag.js) -->
+        <script type="application/ld+json">
+        {
+          "@context": "https://schema.org",
+          "@graph": [
+            {
+              "@type": "WebSite",
+              "@id": "https://www.stateof.ai/index-11-oct-2021#website",
+              "url": "https://www.stateof.ai/",
+              "name": "State of AI Report",
+              "publisher": {
+                "@type": "Organization",
+                "name": "Air Street Capital",
+                "url": "https://www.airstreet.com/"
+              }
+            },
+            {
+              "@type": "CreativeWorkSeries",
+              "@id": "https://www.stateof.ai/index-11-oct-2021#series",
+              "name": "State of AI Report",
+              "description": "The most widely read and trusted independent annual report on global progress in artificial intelligence, covering research, industry, geopolitics, and AI safety.",
+              "inLanguage": "en",
+              "startDate": "2018-01-01",
+              "url": "https://www.stateof.ai/index-11-oct-2021",
+              "creator": {
+                "@type": "Person",
+                "name": "Nathan Benaich",
+                "url": "https://www.nathanbenaich.com/"
+              },
+              "publisher": {
+                "@type": "Organization",
+                "name": "Air Street Capital",
+                "url": "https://www.airstreet.com/"
+              },
+              "keywords": [
+                "State of AI",
+                "State of AI Report",
+                "artificial intelligence",
+                "machine learning",
+                "deep learning",
+                "generative AI",
+                "AI research",
+                "AI industry",
+                "AI geopolitics",
+                "AI safety"
+              ],
+              "sameAs": [
+                "https://x.com/stateofai",
+                "https://www.linkedin.com/company/stateofai/",
+                "https://press.airstreet.com/",
+                "https://www.airstreet.com/"
+              ]
+            }
+          ]
+        }
+        </script>
+<!-- Google tag (gtag.js) -->
         <script async src="https://www.googletagmanager.com/gtag/js?id=G-25T8JQY0LN"></script>
         <script>
           window.dataLayer = window.dataLayer || [];
@@ -17,33 +72,7 @@
         'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
         })(window,document,'script','dataLayer','GTM-NWC2HDM');</script>
         <!-- End Google Tag Manager -->
-        <script type="application/ld+json">
-        {
-          "@context" : "http://schema.org",
-          "@type" : "Article",
-          "headline" : "A Report on the state of AI and its implication for the future.",
-          "name" : "State of AI Report",
-          "about" : "A Report on artificial intelligence research, talent, politics, industry, startups, and China.",
-          "description" : "A Report on artificial intelligence research, talent, politics, industry, startups, and China.",
-          "inLanguage" : "English",
-          "keywords" : ["State of AI Report 2021", "State of AI Report 2020", "State of AI Report 2018", "State of AI Report 2019", "artificial intelligence", "deep learning", "machine learning", "reinforcement learning", "supervised learning", "startups", "venture capital", "State of AI", "State of AI Report", "State of AI Report 2018"],
-          "publisher": {
-            "@type": "Organization",
-            "name": "Air Street Capital"
-          },
-          "author" : [ {
-            "@type" : "Person",
-            "name" : "Nathan Benaich"
-          }, {
-            "@type" : "Person",
-            "name" : "Ian Hogarth"
-          } ],
-          "datePublished" : "2021-10-12",
-          "articleBody" : "We believe that AI will be a force multiplier on technological progress in our increasingly digital, data-driven world. This is because everything around us today, ranging from culture to consumer products, is a product of intelligence.\n              </P>\n              <P class=\"subtext\">\n                In this report, we set out to capture a snapshot of the exponential progress in AI with a focus on developments in the past 12 months. Consider this report as a compilation of the most interesting things we’ve seen that seeks to trigger an informed conversation about the state of AI and its implication for the future. This edition builds on the State of AI Report 2020, which can be <A href=\"https://www.stateof.ai/2018\">found here</A>.\n              </P>\n              <OL> We consider the following key dimensions in our report:\n                  <LI><STRONG>Research:</STRONG> Technology breakthroughs and their capabilities. </LI>\n                  <LI><STRONG>Talent:</STRONG> Supply, demand and concentration of talent working in the field.  </LI>\n                  <LI><STRONG>Industry:</STRONG> Large platforms, financings and areas of application for AI-driven innovation today and tomorrow. </LI>\n                  <LI><STRONG>China:</STRONG> With two distinct internets, we review AI in China as its own category. </LI>\n                  <LI><STRONG>Politics:</STRONG> Public opinion of AI, economic implications and the emerging geopolitics of AI.",
-          "url" : "https://www.stateof.ai"
-        }
-        </script>
-        <title>State of AI Report 2021</title>
+<title>State of AI Report 2021</title>
         <meta charset="utf-8">
         <meta http-equiv="x-ua-compatible" content="ie=edge">
         <meta name="author" content="Nathan Benaich and Ian Hogarth">

--- a/index-2023-oct-9.html
+++ b/index-2023-oct-9.html
@@ -1,7 +1,62 @@
 <!DOCTYPE html>
 <html class="no-js" lang="">
     <head>
-        <!-- Google tag (gtag.js) -->
+        <script type="application/ld+json">
+        {
+          "@context": "https://schema.org",
+          "@graph": [
+            {
+              "@type": "WebSite",
+              "@id": "https://www.stateof.ai/index-2023-oct-9#website",
+              "url": "https://www.stateof.ai/",
+              "name": "State of AI Report",
+              "publisher": {
+                "@type": "Organization",
+                "name": "Air Street Capital",
+                "url": "https://www.airstreet.com/"
+              }
+            },
+            {
+              "@type": "CreativeWorkSeries",
+              "@id": "https://www.stateof.ai/index-2023-oct-9#series",
+              "name": "State of AI Report",
+              "description": "The most widely read and trusted independent annual report on global progress in artificial intelligence, covering research, industry, geopolitics, and AI safety.",
+              "inLanguage": "en",
+              "startDate": "2018-01-01",
+              "url": "https://www.stateof.ai/index-2023-oct-9",
+              "creator": {
+                "@type": "Person",
+                "name": "Nathan Benaich",
+                "url": "https://www.nathanbenaich.com/"
+              },
+              "publisher": {
+                "@type": "Organization",
+                "name": "Air Street Capital",
+                "url": "https://www.airstreet.com/"
+              },
+              "keywords": [
+                "State of AI",
+                "State of AI Report",
+                "artificial intelligence",
+                "machine learning",
+                "deep learning",
+                "generative AI",
+                "AI research",
+                "AI industry",
+                "AI geopolitics",
+                "AI safety"
+              ],
+              "sameAs": [
+                "https://x.com/stateofai",
+                "https://www.linkedin.com/company/stateofai/",
+                "https://press.airstreet.com/",
+                "https://www.airstreet.com/"
+              ]
+            }
+          ]
+        }
+        </script>
+<!-- Google tag (gtag.js) -->
         <script async src="https://www.googletagmanager.com/gtag/js?id=G-25T8JQY0LN"></script>
         <script>
           window.dataLayer = window.dataLayer || [];
@@ -17,30 +72,7 @@
         'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
         })(window,document,'script','dataLayer','GTM-NWC2HDM');</script>
         <!-- End Google Tag Manager -->
-        <script type="application/ld+json">
-        {
-          "@context" : "http://schema.org",
-          "@type" : "Article",
-          "headline" : "A Report on the state of AI and its implication for the future.",
-          "name" : "State of AI Report",
-          "about" : "A Report on artificial intelligence research, talent, politics, industry, safety, startups, and China.",
-          "description" : "A Report on artificial intelligence research, talent, politics, industry, safety, startups, and China.",
-          "inLanguage" : "English",
-          "keywords" : ["State of AI Report 2024", "State of AI Report 2023", "State of AI Report 2022", "State of AI Report 2021", "State of AI Report 2020", "State of AI Report 2018", "State of AI Report 2019", "artificial intelligence", "deep learning", "machine learning", "generative ai", "genai", "reinforcement learning", "supervised learning", "startups", "venture capital", "State of AI", "State of AI Report", "State of AI Report 2018"],
-          "publisher": {
-            "@type": "Organization",
-            "name": "Air Street Capital"
-          },
-          "author" : [ {
-            "@type" : "Person",
-            "name" : "Nathan Benaich"
-          } ],
-          "datePublished" : "2024-10-10",
-          "articleBody" : "We believe that AI will be a force multiplier on technological progress in our increasingly digital, data-driven world. This is because everything around us today, ranging from culture to consumer products, is a product of intelligence.\n              </P>\n              <P class=\"subtext\">\n                In this report, we set out to capture a snapshot of the exponential progress in AI with a focus on developments in the past 12 months. Consider this report as a compilation of the most interesting things we’ve seen that seeks to trigger an informed conversation about the state of AI and its implication for the future. This edition builds on the State of AI Report 2023, which can be <A href=\"https://www.stateof.ai/2023\">found here</A>.\n              </P>\n              <OL> We consider the following key dimensions in our report:\n                  <LI><STRONG>Research:</STRONG> Technology breakthroughs and their capabilities. </LI>\n                  <LI><STRONG>Talent:</STRONG> Supply, demand and concentration of talent working in the field.  </LI>\n                  <LI><STRONG>Industry:</STRONG> Large platforms, financings and areas of application for AI-driven innovation today and tomorrow. </LI>\n                  <LI><STRONG>Politics:</STRONG> Public opinion of AI, economic implications and the emerging geopolitics of AI. </LI>\n                  <LI><STRONG>Safety:</STRONG> How to ensure that highly-capable systems are aligned with our species.",
-          "url" : "https://www.stateof.ai"
-        }
-        </script>
-        <title>Welcome to State of AI Report 2024</title>
+<title>Welcome to State of AI Report 2024</title>
         <meta charset="utf-8">
         <meta http-equiv="x-ua-compatible" content="ie=edge">
         <meta name="author" content="Nathan Benaich and Air Street Capital">

--- a/index-2023-pre-launch-staging.html
+++ b/index-2023-pre-launch-staging.html
@@ -1,7 +1,62 @@
 <!DOCTYPE html>
 <html class="no-js" lang="">
     <head>
-        <!-- Google tag (gtag.js) -->
+        <script type="application/ld+json">
+        {
+          "@context": "https://schema.org",
+          "@graph": [
+            {
+              "@type": "WebSite",
+              "@id": "https://www.stateof.ai/index-2023-pre-launch-staging#website",
+              "url": "https://www.stateof.ai/",
+              "name": "State of AI Report",
+              "publisher": {
+                "@type": "Organization",
+                "name": "Air Street Capital",
+                "url": "https://www.airstreet.com/"
+              }
+            },
+            {
+              "@type": "CreativeWorkSeries",
+              "@id": "https://www.stateof.ai/index-2023-pre-launch-staging#series",
+              "name": "State of AI Report",
+              "description": "The most widely read and trusted independent annual report on global progress in artificial intelligence, covering research, industry, geopolitics, and AI safety.",
+              "inLanguage": "en",
+              "startDate": "2018-01-01",
+              "url": "https://www.stateof.ai/index-2023-pre-launch-staging",
+              "creator": {
+                "@type": "Person",
+                "name": "Nathan Benaich",
+                "url": "https://www.nathanbenaich.com/"
+              },
+              "publisher": {
+                "@type": "Organization",
+                "name": "Air Street Capital",
+                "url": "https://www.airstreet.com/"
+              },
+              "keywords": [
+                "State of AI",
+                "State of AI Report",
+                "artificial intelligence",
+                "machine learning",
+                "deep learning",
+                "generative AI",
+                "AI research",
+                "AI industry",
+                "AI geopolitics",
+                "AI safety"
+              ],
+              "sameAs": [
+                "https://x.com/stateofai",
+                "https://www.linkedin.com/company/stateofai/",
+                "https://press.airstreet.com/",
+                "https://www.airstreet.com/"
+              ]
+            }
+          ]
+        }
+        </script>
+<!-- Google tag (gtag.js) -->
         <script async src="https://www.googletagmanager.com/gtag/js?id=G-25T8JQY0LN"></script>
         <script>
           window.dataLayer = window.dataLayer || [];
@@ -17,30 +72,7 @@
         'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
         })(window,document,'script','dataLayer','GTM-NWC2HDM');</script>
         <!-- End Google Tag Manager -->
-        <script type="application/ld+json">
-        {
-          "@context" : "http://schema.org",
-          "@type" : "Article",
-          "headline" : "A Report on the state of AI and its implication for the future.",
-          "name" : "State of AI Report",
-          "about" : "A Report on artificial intelligence research, talent, politics, industry, startups, and China.",
-          "description" : "A Report on artificial intelligence research, talent, politics, industry, startups, and China.",
-          "inLanguage" : "English",
-          "keywords" : ["State of AI Report 2023", "State of AI Report 2022", "State of AI Report 2021", "State of AI Report 2020", "State of AI Report 2018", "State of AI Report 2019", "artificial intelligence", "deep learning", "machine learning", "generative ai", "genai", "reinforcement learning", "supervised learning", "startups", "venture capital", "State of AI", "State of AI Report", "State of AI Report 2018"],
-          "publisher": {
-            "@type": "Organization",
-            "name": "Air Street Capital"
-          },
-          "author" : [ {
-            "@type" : "Person",
-            "name" : "Nathan Benaich"
-          } ],
-          "datePublished" : "2023-10-12",
-          "articleBody" : "We believe that AI will be a force multiplier on technological progress in our increasingly digital, data-driven world. This is because everything around us today, ranging from culture to consumer products, is a product of intelligence.\n              </P>\n              <P class=\"subtext\">\n                In this report, we set out to capture a snapshot of the exponential progress in AI with a focus on developments in the past 12 months. Consider this report as a compilation of the most interesting things we’ve seen that seeks to trigger an informed conversation about the state of AI and its implication for the future. This edition builds on the State of AI Report 2022, which can be <A href=\"https://www.stateof.ai/2022\">found here</A>.\n              </P>\n              <OL> We consider the following key dimensions in our report:\n                  <LI><STRONG>Research:</STRONG> Technology breakthroughs and their capabilities. </LI>\n                  <LI><STRONG>Talent:</STRONG> Supply, demand and concentration of talent working in the field.  </LI>\n                  <LI><STRONG>Industry:</STRONG> Large platforms, financings and areas of application for AI-driven innovation today and tomorrow. </LI>\n                  <LI><STRONG>Politics:</STRONG> Public opinion of AI, economic implications and the emerging geopolitics of AI. </LI>\n                  <LI><STRONG>Safety:</STRONG> How to ensure that highly-capable systems are aligned with our species.",
-          "url" : "https://www.stateof.ai"
-        }
-        </script>
-        <title>Welcome to the State of AI Report 2023</title>
+<title>Welcome to the State of AI Report 2023</title>
         <meta charset="utf-8">
         <meta http-equiv="x-ua-compatible" content="ie=edge">
         <meta name="author" content="Nathan Benaich and Air Street Capital">

--- a/index-5-oct-2021.html
+++ b/index-5-oct-2021.html
@@ -1,7 +1,62 @@
 <!DOCTYPE html>
 <html class="no-js" lang="">
     <head>
-        <!-- Google tag (gtag.js) -->
+        <script type="application/ld+json">
+        {
+          "@context": "https://schema.org",
+          "@graph": [
+            {
+              "@type": "WebSite",
+              "@id": "https://www.stateof.ai/index-5-oct-2021#website",
+              "url": "https://www.stateof.ai/",
+              "name": "State of AI Report",
+              "publisher": {
+                "@type": "Organization",
+                "name": "Air Street Capital",
+                "url": "https://www.airstreet.com/"
+              }
+            },
+            {
+              "@type": "CreativeWorkSeries",
+              "@id": "https://www.stateof.ai/index-5-oct-2021#series",
+              "name": "State of AI Report",
+              "description": "The most widely read and trusted independent annual report on global progress in artificial intelligence, covering research, industry, geopolitics, and AI safety.",
+              "inLanguage": "en",
+              "startDate": "2018-01-01",
+              "url": "https://www.stateof.ai/index-5-oct-2021",
+              "creator": {
+                "@type": "Person",
+                "name": "Nathan Benaich",
+                "url": "https://www.nathanbenaich.com/"
+              },
+              "publisher": {
+                "@type": "Organization",
+                "name": "Air Street Capital",
+                "url": "https://www.airstreet.com/"
+              },
+              "keywords": [
+                "State of AI",
+                "State of AI Report",
+                "artificial intelligence",
+                "machine learning",
+                "deep learning",
+                "generative AI",
+                "AI research",
+                "AI industry",
+                "AI geopolitics",
+                "AI safety"
+              ],
+              "sameAs": [
+                "https://x.com/stateofai",
+                "https://www.linkedin.com/company/stateofai/",
+                "https://press.airstreet.com/",
+                "https://www.airstreet.com/"
+              ]
+            }
+          ]
+        }
+        </script>
+<!-- Google tag (gtag.js) -->
         <script async src="https://www.googletagmanager.com/gtag/js?id=G-25T8JQY0LN"></script>
         <script>
           window.dataLayer = window.dataLayer || [];
@@ -17,34 +72,7 @@
         'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
         })(window,document,'script','dataLayer','GTM-NWC2HDM');</script>
         <!-- End Google Tag Manager -->
-        <script type="application/ld+json">
-        {
-          "@context" : "http://schema.org",
-          "@type" : "Article",
-          "headline" : "A Report on the state of AI and its implication for the future.",
-          "name" : "State of AI Report",
-          "about" : "A Report on artificial intelligence research, talent, politics, industry, startups, and China.",
-          "description" : "A Report on artificial intelligence research, talent, politics, industry, startups, and China.",
-          "inLanguage" : "English",
-          "image" : "https://www.slideshare.net/StateofAIReport/state-of-ai-report-2019-151804430",
-          "keywords" : ["State of AI Report 2020", "State of AI Report 2018", "State of AI Report 2019", "artificial intelligence", "deep learning", "machine learning", "reinforcement learning", "supervised learning", "startups", "venture capital", "State of AI", "State of AI Report", "State of AI Report 2018"],
-          "publisher": {
-            "@type": "Organization",
-            "name": "Air Street Capital"
-          },
-          "author" : [ {
-            "@type" : "Person",
-            "name" : "Nathan Benaich"
-          }, {
-            "@type" : "Person",
-            "name" : "Ian Hogarth"
-          } ],
-          "datePublished" : "2019-06-28",
-          "articleBody" : "We believe that AI will be a force multiplier on technological progress in our increasingly digital, data-driven world. This is because everything around us today, ranging from culture to consumer products, is a product of intelligence.\n              </P>\n              <P class=\"subtext\">\n                In this report, we set out to capture a snapshot of the exponential progress in AI with a focus on developments in the past 12 months. Consider this report as a compilation of the most interesting things we’ve seen that seeks to trigger an informed conversation about the state of AI and its implication for the future. This edition builds on the inaugural State of AI Report 2018, which can be <A href=\"https://www.stateof.ai/2018\">found here</A>.\n              </P>\n              <OL> We consider the following key dimensions in our report:\n                  <LI><STRONG>Research:</STRONG> Technology breakthroughs and their capabilities. </LI>\n                  <LI><STRONG>Talent:</STRONG> Supply, demand and concentration of talent working in the field.  </LI>\n                  <LI><STRONG>Industry:</STRONG> Large platforms, financings and areas of application for AI-driven innovation today and tomorrow. </LI>\n                  <LI><STRONG>China:</STRONG> With two distinct internets, we review AI in China as its own category. </LI>\n                  <LI><STRONG>Politics:</STRONG> Public opinion of AI, economic implications and the emerging geopolitics of AI.",
-          "url" : "https://www.slideshare.net/StateofAIReport/state-of-ai-report-2019-151804430"
-        }
-        </script>
-        <title>State of AI Report 2020</title>
+<title>State of AI Report 2020</title>
         <meta charset="utf-8">
         <meta http-equiv="x-ua-compatible" content="ie=edge">
         <meta name="author" content="Nathan Benaich and Ian Hogarth">

--- a/index-PUSHLAasdfadfeaaUNCHDAY.html
+++ b/index-PUSHLAasdfadfeaaUNCHDAY.html
@@ -1,7 +1,62 @@
 <!DOCTYPE html>
 <html class="no-js" lang="">
     <head>
-        <!-- Google tag (gtag.js) -->
+        <script type="application/ld+json">
+        {
+          "@context": "https://schema.org",
+          "@graph": [
+            {
+              "@type": "WebSite",
+              "@id": "https://www.stateof.ai/index-PUSHLAasdfadfeaaUNCHDAY#website",
+              "url": "https://www.stateof.ai/",
+              "name": "State of AI Report",
+              "publisher": {
+                "@type": "Organization",
+                "name": "Air Street Capital",
+                "url": "https://www.airstreet.com/"
+              }
+            },
+            {
+              "@type": "CreativeWorkSeries",
+              "@id": "https://www.stateof.ai/index-PUSHLAasdfadfeaaUNCHDAY#series",
+              "name": "State of AI Report",
+              "description": "The most widely read and trusted independent annual report on global progress in artificial intelligence, covering research, industry, geopolitics, and AI safety.",
+              "inLanguage": "en",
+              "startDate": "2018-01-01",
+              "url": "https://www.stateof.ai/index-PUSHLAasdfadfeaaUNCHDAY",
+              "creator": {
+                "@type": "Person",
+                "name": "Nathan Benaich",
+                "url": "https://www.nathanbenaich.com/"
+              },
+              "publisher": {
+                "@type": "Organization",
+                "name": "Air Street Capital",
+                "url": "https://www.airstreet.com/"
+              },
+              "keywords": [
+                "State of AI",
+                "State of AI Report",
+                "artificial intelligence",
+                "machine learning",
+                "deep learning",
+                "generative AI",
+                "AI research",
+                "AI industry",
+                "AI geopolitics",
+                "AI safety"
+              ],
+              "sameAs": [
+                "https://x.com/stateofai",
+                "https://www.linkedin.com/company/stateofai/",
+                "https://press.airstreet.com/",
+                "https://www.airstreet.com/"
+              ]
+            }
+          ]
+        }
+        </script>
+<!-- Google tag (gtag.js) -->
         <script async src="https://www.googletagmanager.com/gtag/js?id=G-25T8JQY0LN"></script>
         <script>
           window.dataLayer = window.dataLayer || [];
@@ -17,33 +72,7 @@
         'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
         })(window,document,'script','dataLayer','GTM-NWC2HDM');</script>
         <!-- End Google Tag Manager -->
-        <script type="application/ld+json">
-        {
-          "@context" : "http://schema.org",
-          "@type" : "Article",
-          "headline" : "A Report on the state of AI and its implication for the future.",
-          "name" : "State of AI Report",
-          "about" : "A Report on artificial intelligence research, talent, politics, industry, startups, safety, and China.",
-          "description" : "A Report on artificial intelligence research, talent, politics, industry, startups, safety, and China.",
-          "inLanguage" : "English",
-          "keywords" : ["State of AI Report 2022", "State of AI Report 2021", "State of AI Report 2020", "State of AI Report 2018", "State of AI Report 2019", "artificial intelligence", "deep learning", "machine learning", "reinforcement learning", "supervised learning", "startups", "venture capital", "State of AI", "State of AI Report", "State of AI Report 2018"],
-          "publisher": {
-            "@type": "Organization",
-            "name": "Air Street Capital"
-          },
-          "author" : [ {
-            "@type" : "Person",
-            "name" : "Nathan Benaich"
-          }, {
-            "@type" : "Person",
-            "name" : "Ian Hogarth"
-          } ],
-          "datePublished" : "2022-10-11",
-          "articleBody" : "We believe that AI will be a force multiplier on technological progress in our increasingly digital, data-driven world. This is because everything around us today, ranging from culture to consumer products, is a product of intelligence.\n              </P>\n              <P class=\"subtext\">\n                In this report, we set out to capture a snapshot of the exponential progress in AI with a focus on developments in the past 12 months. Consider this report as a compilation of the most interesting things we’ve seen that seeks to trigger an informed conversation about the state of AI and its implication for the future. This edition builds on the State of AI Report 2021, which can be <A href=\"https://www.stateof.ai/2021\">found here</A>.\n              </P>\n              <OL> We consider the following key dimensions in our report:\n                  <LI><STRONG>Research:</STRONG> Technology breakthroughs and their capabilities. </LI>\n                  <LI><STRONG>Talent:</STRONG> Supply, demand and concentration of talent working in the field.  </LI>\n                  <LI><STRONG>Industry:</STRONG> Large platforms, financings and areas of application for AI-driven innovation today and tomorrow. </LI>\n                  <LI><STRONG>Politics:</STRONG> Public opinion of AI, economic implications and the emerging geopolitics of AI. </LI>\n                  <LI><STRONG>Safety:</STRONG> How to ensure that highly-capable systems are aligned with our species.",
-          "url" : "https://www.stateof.ai"
-        }
-        </script>
-        <title>State of AI Report 2022</title>
+<title>State of AI Report 2022</title>
         <meta charset="utf-8">
         <meta http-equiv="x-ua-compatible" content="ie=edge">
         <meta name="author" content="Nathan Benaich and Ian Hogarth">

--- a/index-old-8-oct-2025.html
+++ b/index-old-8-oct-2025.html
@@ -1,7 +1,62 @@
 <!DOCTYPE html>
 <html class="no-js" lang="">
     <head>
-        <!-- Google tag (gtag.js) -->
+        <script type="application/ld+json">
+        {
+          "@context": "https://schema.org",
+          "@graph": [
+            {
+              "@type": "WebSite",
+              "@id": "https://www.stateof.ai/index-old-8-oct-2025#website",
+              "url": "https://www.stateof.ai/",
+              "name": "State of AI Report",
+              "publisher": {
+                "@type": "Organization",
+                "name": "Air Street Capital",
+                "url": "https://www.airstreet.com/"
+              }
+            },
+            {
+              "@type": "CreativeWorkSeries",
+              "@id": "https://www.stateof.ai/index-old-8-oct-2025#series",
+              "name": "State of AI Report",
+              "description": "The most widely read and trusted independent annual report on global progress in artificial intelligence, covering research, industry, geopolitics, and AI safety.",
+              "inLanguage": "en",
+              "startDate": "2018-01-01",
+              "url": "https://www.stateof.ai/index-old-8-oct-2025",
+              "creator": {
+                "@type": "Person",
+                "name": "Nathan Benaich",
+                "url": "https://www.nathanbenaich.com/"
+              },
+              "publisher": {
+                "@type": "Organization",
+                "name": "Air Street Capital",
+                "url": "https://www.airstreet.com/"
+              },
+              "keywords": [
+                "State of AI",
+                "State of AI Report",
+                "artificial intelligence",
+                "machine learning",
+                "deep learning",
+                "generative AI",
+                "AI research",
+                "AI industry",
+                "AI geopolitics",
+                "AI safety"
+              ],
+              "sameAs": [
+                "https://x.com/stateofai",
+                "https://www.linkedin.com/company/stateofai/",
+                "https://press.airstreet.com/",
+                "https://www.airstreet.com/"
+              ]
+            }
+          ]
+        }
+        </script>
+<!-- Google tag (gtag.js) -->
         <script async src="https://www.googletagmanager.com/gtag/js?id=G-25T8JQY0LN"></script>
         <script>
           window.dataLayer = window.dataLayer || [];
@@ -17,30 +72,7 @@
         'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
         })(window,document,'script','dataLayer','GTM-NWC2HDM');</script>
         <!-- End Google Tag Manager -->
-        <script type="application/ld+json">
-        {
-          "@context" : "http://schema.org",
-          "@type" : "Article",
-          "headline" : "A Report on the state of AI and its implication for the future.",
-          "name" : "State of AI Report",
-          "about" : "A Report on artificial intelligence research, talent, politics, industry, safety, startups, and China.",
-          "description" : "A Report on artificial intelligence research, talent, politics, industry, safety, startups, and China.",
-          "inLanguage" : "English",
-          "keywords" : ["State of AI Report 2025", "State of AI Report 2024", "State of AI Report 2023", "State of AI Report 2022", "State of AI Report 2021", "State of AI Report 2020", "State of AI Report 2018", "State of AI Report 2019", "artificial intelligence", "deep learning", "machine learning", "generative ai", "genai", "reinforcement learning", "supervised learning", "startups", "venture capital", "State of AI", "State of AI Report", "State of AI Report 2018"],
-          "publisher": {
-            "@type": "Organization",
-            "name": "Air Street Capital"
-          },
-          "author" : [ {
-            "@type" : "Person",
-            "name" : "Nathan Benaich"
-          } ],
-          "datePublished" : "2025-10-09",
-          "articleBody" : "We believe that AI will be a force multiplier on technological progress in our increasingly digital, data-driven world. This is because everything around us today, ranging from culture to consumer products, is a product of intelligence.\n              </P>\n              <P class=\"subtext\">\n                In this report, we set out to capture a snapshot of the exponential progress in AI with a focus on developments in the past 12 months. Consider this report as a compilation of the most interesting things we’ve seen that seeks to trigger an informed conversation about the state of AI and its implication for the future. This edition builds on the State of AI Report 2024, which can be <A href=\"https://www.stateof.ai/2023\">found here</A>.\n              </P>\n              <OL> We consider the following key dimensions in our report:\n                  <LI><STRONG>Research:</STRONG> Technology breakthroughs and their capabilities. </LI>\n                  <LI><STRONG>Talent:</STRONG> Supply, demand and concentration of talent working in the field.  </LI>\n                  <LI><STRONG>Industry:</STRONG> Large platforms, financings and areas of application for AI-driven innovation today and tomorrow. </LI>\n                  <LI><STRONG>Politics:</STRONG> Public opinion of AI, economic implications and the emerging geopolitics of AI. </LI>\n                  <LI><STRONG>Safety:</STRONG> How to ensure that highly-capable systems are aligned with our species.",
-          "url" : "https://www.stateof.ai"
-        }
-        </script>
-        <title>Welcome to State of AI Report 2025</title>
+<title>Welcome to State of AI Report 2025</title>
         <meta charset="utf-8">
         <meta http-equiv="x-ua-compatible" content="ie=edge">
         <meta name="author" content="Nathan Benaich and Air Street Capital">

--- a/index-old.html
+++ b/index-old.html
@@ -1,7 +1,62 @@
 <!DOCTYPE html>
 <html class="no-js" lang="">
     <head>
-        <!-- Google tag (gtag.js) -->
+        <script type="application/ld+json">
+        {
+          "@context": "https://schema.org",
+          "@graph": [
+            {
+              "@type": "WebSite",
+              "@id": "https://www.stateof.ai/index-old#website",
+              "url": "https://www.stateof.ai/",
+              "name": "State of AI Report",
+              "publisher": {
+                "@type": "Organization",
+                "name": "Air Street Capital",
+                "url": "https://www.airstreet.com/"
+              }
+            },
+            {
+              "@type": "CreativeWorkSeries",
+              "@id": "https://www.stateof.ai/index-old#series",
+              "name": "State of AI Report",
+              "description": "The most widely read and trusted independent annual report on global progress in artificial intelligence, covering research, industry, geopolitics, and AI safety.",
+              "inLanguage": "en",
+              "startDate": "2018-01-01",
+              "url": "https://www.stateof.ai/index-old",
+              "creator": {
+                "@type": "Person",
+                "name": "Nathan Benaich",
+                "url": "https://www.nathanbenaich.com/"
+              },
+              "publisher": {
+                "@type": "Organization",
+                "name": "Air Street Capital",
+                "url": "https://www.airstreet.com/"
+              },
+              "keywords": [
+                "State of AI",
+                "State of AI Report",
+                "artificial intelligence",
+                "machine learning",
+                "deep learning",
+                "generative AI",
+                "AI research",
+                "AI industry",
+                "AI geopolitics",
+                "AI safety"
+              ],
+              "sameAs": [
+                "https://x.com/stateofai",
+                "https://www.linkedin.com/company/stateofai/",
+                "https://press.airstreet.com/",
+                "https://www.airstreet.com/"
+              ]
+            }
+          ]
+        }
+        </script>
+<!-- Google tag (gtag.js) -->
         <script async src="https://www.googletagmanager.com/gtag/js?id=G-25T8JQY0LN"></script>
         <script>
           window.dataLayer = window.dataLayer || [];
@@ -17,34 +72,7 @@
         'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
         })(window,document,'script','dataLayer','GTM-NWC2HDM');</script>
         <!-- End Google Tag Manager -->
-        <script type="application/ld+json">
-        {
-          "@context" : "http://schema.org",
-          "@type" : "Article",
-          "headline" : "A Report on the state of AI and its implication for the future.",
-          "name" : "State of AI Report",
-          "about" : "A Report on artificial intelligence research, talent, politics, industry, startups, and China.",
-          "description" : "A Report on artificial intelligence research, talent, politics, industry, startups, and China.",
-          "inLanguage" : "English",
-          "image" : "https://www.slideshare.net/StateofAIReport/state-of-ai-report-2019-151804430",
-          "keywords" : ["State of AI Report 2020", "State of AI Report 2018", "State of AI Report 2019", "artificial intelligence", "deep learning", "machine learning", "reinforcement learning", "supervised learning", "startups", "venture capital", "State of AI", "State of AI Report", "State of AI Report 2018"],
-          "publisher": {
-            "@type": "Organization",
-            "name": "Air Street Capital"
-          },
-          "author" : [ {
-            "@type" : "Person",
-            "name" : "Nathan Benaich"
-          }, {
-            "@type" : "Person",
-            "name" : "Ian Hogarth"
-          } ],
-          "datePublished" : "2019-06-28",
-          "articleBody" : "We believe that AI will be a force multiplier on technological progress in our increasingly digital, data-driven world. This is because everything around us today, ranging from culture to consumer products, is a product of intelligence.\n              </P>\n              <P class=\"subtext\">\n                In this report, we set out to capture a snapshot of the exponential progress in AI with a focus on developments in the past 12 months. Consider this report as a compilation of the most interesting things we’ve seen that seeks to trigger an informed conversation about the state of AI and its implication for the future..\n              </P>\n              <OL> We consider the following key dimensions in our report:\n                  <LI><STRONG>Research:</STRONG> Technology breakthroughs and their capabilities. </LI>\n                  <LI><STRONG>Talent:</STRONG> Supply, demand and concentration of talent working in the field.  </LI>\n                  <LI><STRONG>Industry:</STRONG> Large platforms, financings and areas of application for AI-driven innovation today and tomorrow. </LI>\n                  <LI><STRONG>China:</STRONG> With two distinct internets, we review AI in China as its own category. </LI>\n                  <LI><STRONG>Politics:</STRONG> Public opinion of AI, economic implications and the emerging geopolitics of AI.",
-          "url" : "https://www.slideshare.net/StateofAIReport/state-of-ai-report-2019-151804430"
-        }
-        </script>
-        <title>State of AI Report 2020</title>
+<title>State of AI Report 2020</title>
         <meta charset="utf-8">
         <meta http-equiv="x-ua-compatible" content="ie=edge">
         <meta name="author" content="Nathan Benaich and Ian Hogarth">

--- a/index.html
+++ b/index.html
@@ -1,23 +1,6 @@
 <!DOCTYPE html>
 <html class="no-js" lang="en">
     <head>
-        <!-- Google tag (gtag.js) -->
-        <script async src="https://www.googletagmanager.com/gtag/js?id=G-25T8JQY0LN"></script>
-        <script>
-          window.dataLayer = window.dataLayer || [];
-          function gtag(){dataLayer.push(arguments);}
-          gtag('js', new Date());
-
-          gtag('config', 'G-25T8JQY0LN');
-        </script>
-        <!-- Google Tag Manager -->
-        <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-        new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-        j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-        'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-        })(window,document,'script','dataLayer','GTM-NWC2HDM');</script>
-        <!-- End Google Tag Manager -->
-
         <script type="application/ld+json">
         {
           "@context": "https://schema.org",
@@ -73,8 +56,23 @@
           ]
         }
         </script>
+<!-- Google tag (gtag.js) -->
+        <script async src="https://www.googletagmanager.com/gtag/js?id=G-25T8JQY0LN"></script>
+        <script>
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){dataLayer.push(arguments);}
+          gtag('js', new Date());
 
-        <title>Welcome to State of AI Report 2025</title>
+          gtag('config', 'G-25T8JQY0LN');
+        </script>
+        <!-- Google Tag Manager -->
+        <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+        new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+        j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+        'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+        })(window,document,'script','dataLayer','GTM-NWC2HDM');</script>
+        <!-- End Google Tag Manager -->
+<title>Welcome to State of AI Report 2025</title>
         <meta charset="utf-8">
         <meta http-equiv="x-ua-compatible" content="ie=edge">
         <meta name="author" content="Nathan Benaich and Air Street Capital">

--- a/launch.html
+++ b/launch.html
@@ -1,7 +1,62 @@
 <!DOCTYPE html>
 <html class="no-js" lang="">
     <head>
-        <!-- Google tag (gtag.js) -->
+        <script type="application/ld+json">
+        {
+          "@context": "https://schema.org",
+          "@graph": [
+            {
+              "@type": "WebSite",
+              "@id": "https://www.stateof.ai/launch#website",
+              "url": "https://www.stateof.ai/",
+              "name": "State of AI Report",
+              "publisher": {
+                "@type": "Organization",
+                "name": "Air Street Capital",
+                "url": "https://www.airstreet.com/"
+              }
+            },
+            {
+              "@type": "CreativeWorkSeries",
+              "@id": "https://www.stateof.ai/launch#series",
+              "name": "State of AI Report",
+              "description": "The most widely read and trusted independent annual report on global progress in artificial intelligence, covering research, industry, geopolitics, and AI safety.",
+              "inLanguage": "en",
+              "startDate": "2018-01-01",
+              "url": "https://www.stateof.ai/launch",
+              "creator": {
+                "@type": "Person",
+                "name": "Nathan Benaich",
+                "url": "https://www.nathanbenaich.com/"
+              },
+              "publisher": {
+                "@type": "Organization",
+                "name": "Air Street Capital",
+                "url": "https://www.airstreet.com/"
+              },
+              "keywords": [
+                "State of AI",
+                "State of AI Report",
+                "artificial intelligence",
+                "machine learning",
+                "deep learning",
+                "generative AI",
+                "AI research",
+                "AI industry",
+                "AI geopolitics",
+                "AI safety"
+              ],
+              "sameAs": [
+                "https://x.com/stateofai",
+                "https://www.linkedin.com/company/stateofai/",
+                "https://press.airstreet.com/",
+                "https://www.airstreet.com/"
+              ]
+            }
+          ]
+        }
+        </script>
+<!-- Google tag (gtag.js) -->
         <script async src="https://www.googletagmanager.com/gtag/js?id=G-25T8JQY0LN"></script>
         <script>
           window.dataLayer = window.dataLayer || [];
@@ -17,33 +72,7 @@
         'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
         })(window,document,'script','dataLayer','GTM-NWC2HDM');</script>
         <!-- End Google Tag Manager -->
-        <script type="application/ld+json">
-        {
-          "@context" : "http://schema.org",
-          "@type" : "Article",
-          "headline" : "A Report on the state of AI and its implication for the future.",
-          "name" : "State of AI Report",
-          "about" : "A Report on artificial intelligence research, talent, politics, industry, startups, safety, and China.",
-          "description" : "A Report on artificial intelligence research, talent, politics, industry, startups, safety, and China.",
-          "inLanguage" : "English",
-          "keywords" : ["State of AI Report 2022", "State of AI Report 2021", "State of AI Report 2020", "State of AI Report 2018", "State of AI Report 2019", "artificial intelligence", "deep learning", "machine learning", "reinforcement learning", "supervised learning", "startups", "venture capital", "State of AI", "State of AI Report", "State of AI Report 2018"],
-          "publisher": {
-            "@type": "Organization",
-            "name": "Air Street Capital"
-          },
-          "author" : [ {
-            "@type" : "Person",
-            "name" : "Nathan Benaich"
-          }, {
-            "@type" : "Person",
-            "name" : "Ian Hogarth"
-          } ],
-          "datePublished" : "2022-10-11",
-          "articleBody" : "We believe that AI will be a force multiplier on technological progress in our increasingly digital, data-driven world. This is because everything around us today, ranging from culture to consumer products, is a product of intelligence.\n              </P>\n              <P class=\"subtext\">\n                In this report, we set out to capture a snapshot of the exponential progress in AI with a focus on developments in the past 12 months. Consider this report as a compilation of the most interesting things we’ve seen that seeks to trigger an informed conversation about the state of AI and its implication for the future. This edition builds on the State of AI Report 2022, which can be <A href=\"https://www.stateof.ai/2022\">found here</A>.\n              </P>\n              <OL> We consider the following key dimensions in our report:\n                  <LI><STRONG>Research:</STRONG> Technology breakthroughs and their capabilities. </LI>\n                  <LI><STRONG>Talent:</STRONG> Supply, demand and concentration of talent working in the field.  </LI>\n                  <LI><STRONG>Industry:</STRONG> Large platforms, financings and areas of application for AI-driven innovation today and tomorrow. </LI>\n                  <LI><STRONG>Politics:</STRONG> Public opinion of AI, economic implications and the emerging geopolitics of AI. </LI>\n                  <LI><STRONG>Safety:</STRONG> How to ensure that highly-capable systems are aligned with our species.",
-          "url" : "https://www.stateof.ai"
-        }
-        </script>
-        <title>State of AI Report 2022</title>
+<title>State of AI Report 2022</title>
         <meta charset="utf-8">
         <meta http-equiv="x-ua-compatible" content="ie=edge">
         <meta name="author" content="Nathan Benaich and Ian Hogarth">

--- a/subscribe.html
+++ b/subscribe.html
@@ -1,7 +1,62 @@
 <!DOCTYPE html>
 <html class="no-js" lang="">
     <head>
-        <!-- Google tag (gtag.js) -->
+        <script type="application/ld+json">
+        {
+          "@context": "https://schema.org",
+          "@graph": [
+            {
+              "@type": "WebSite",
+              "@id": "https://www.stateof.ai/subscribe#website",
+              "url": "https://www.stateof.ai/",
+              "name": "State of AI Report",
+              "publisher": {
+                "@type": "Organization",
+                "name": "Air Street Capital",
+                "url": "https://www.airstreet.com/"
+              }
+            },
+            {
+              "@type": "CreativeWorkSeries",
+              "@id": "https://www.stateof.ai/subscribe#series",
+              "name": "State of AI Report",
+              "description": "The most widely read and trusted independent annual report on global progress in artificial intelligence, covering research, industry, geopolitics, and AI safety.",
+              "inLanguage": "en",
+              "startDate": "2018-01-01",
+              "url": "https://www.stateof.ai/subscribe",
+              "creator": {
+                "@type": "Person",
+                "name": "Nathan Benaich",
+                "url": "https://www.nathanbenaich.com/"
+              },
+              "publisher": {
+                "@type": "Organization",
+                "name": "Air Street Capital",
+                "url": "https://www.airstreet.com/"
+              },
+              "keywords": [
+                "State of AI",
+                "State of AI Report",
+                "artificial intelligence",
+                "machine learning",
+                "deep learning",
+                "generative AI",
+                "AI research",
+                "AI industry",
+                "AI geopolitics",
+                "AI safety"
+              ],
+              "sameAs": [
+                "https://x.com/stateofai",
+                "https://www.linkedin.com/company/stateofai/",
+                "https://press.airstreet.com/",
+                "https://www.airstreet.com/"
+              ]
+            }
+          ]
+        }
+        </script>
+<!-- Google tag (gtag.js) -->
         <script async src="https://www.googletagmanager.com/gtag/js?id=G-25T8JQY0LN"></script>
         <script>
           window.dataLayer = window.dataLayer || [];
@@ -17,31 +72,7 @@
         'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
         })(window,document,'script','dataLayer','GTM-NWC2HDM');</script>
         <!-- End Google Tag Manager -->
-        <script type="application/ld+json">
-        {
-          "@context" : "http://schema.org",
-          "@type" : "Article",
-          "headline" : "A Report on the state of AI and its implication for the future.",
-          "name" : "State of AI Report",
-          "about" : "A Report on artificial intelligence research, talent, politics, industry, startups, and China.",
-          "description" : "A Report on artificial intelligence research, talent, politics, industry, startups, and China.",
-          "inLanguage" : "English",
-          "image" : "https://www.slideshare.net/StateofAIReport/state-of-ai-report-2019-151804430",
-          "keywords" : ["State of AI Report 2020", "State of AI Report 2018", "State of AI Report 2019", "artificial intelligence", "deep learning", "machine learning", "reinforcement learning", "supervised learning", "startups", "venture capital", "State of AI", "State of AI Report", "State of AI Report 2018"],
-          "publisher": {
-            "@type": "Organization",
-            "name": "Air Street Capital"
-          },
-          "author" : [ {
-            "@type" : "Person",
-            "name" : "Nathan Benaich"
-          },],
-          "datePublished" : "2019-06-28",
-          "articleBody" : "We believe that AI will be a force multiplier on technological progress in our increasingly digital, data-driven world. This is because everything around us today, ranging from culture to consumer products, is a product of intelligence.\n              </P>\n              <P class=\"subtext\">\n                In this report, we set out to capture a snapshot of the exponential progress in AI with a focus on developments in the past 12 months. Consider this report as a compilation of the most interesting things we’ve seen that seeks to trigger an informed conversation about the state of AI and its implication for the future. This edition builds on the inaugural State of AI Report 2018, which can be <A href=\"https://www.stateof.ai/2018\">found here</A>.\n              </P>\n              <OL> We consider the following key dimensions in our report:\n                  <LI><STRONG>Research:</STRONG> Technology breakthroughs and their capabilities. </LI>\n                  <LI><STRONG>Talent:</STRONG> Supply, demand and concentration of talent working in the field.  </LI>\n                  <LI><STRONG>Industry:</STRONG> Large platforms, financings and areas of application for AI-driven innovation today and tomorrow. </LI>\n                  <LI><STRONG>China:</STRONG> With two distinct internets, we review AI in China as its own category. </LI>\n                  <LI><STRONG>Politics:</STRONG> Public opinion of AI, economic implications and the emerging geopolitics of AI.",
-          "url" : "https://www.slideshare.net/StateofAIReport/state-of-ai-report-2019-151804430"
-        }
-        </script>
-        <title>State of AI Report 2025</title>
+<title>State of AI Report 2025</title>
         <meta charset="utf-8">
         <meta http-equiv="x-ua-compatible" content="ie=edge">
         <meta name="author" content="Nathan Benaich">

--- a/survey-2025.html
+++ b/survey-2025.html
@@ -1,7 +1,62 @@
 <!DOCTYPE html>
 <html class="no-js" lang="">
     <head>
-        <!-- Google tag (gtag.js) -->
+        <script type="application/ld+json">
+        {
+          "@context": "https://schema.org",
+          "@graph": [
+            {
+              "@type": "WebSite",
+              "@id": "https://www.stateof.ai/survey-2025#website",
+              "url": "https://www.stateof.ai/",
+              "name": "State of AI Report",
+              "publisher": {
+                "@type": "Organization",
+                "name": "Air Street Capital",
+                "url": "https://www.airstreet.com/"
+              }
+            },
+            {
+              "@type": "CreativeWorkSeries",
+              "@id": "https://www.stateof.ai/survey-2025#series",
+              "name": "State of AI Report",
+              "description": "The most widely read and trusted independent annual report on global progress in artificial intelligence, covering research, industry, geopolitics, and AI safety.",
+              "inLanguage": "en",
+              "startDate": "2018-01-01",
+              "url": "https://www.stateof.ai/survey-2025",
+              "creator": {
+                "@type": "Person",
+                "name": "Nathan Benaich",
+                "url": "https://www.nathanbenaich.com/"
+              },
+              "publisher": {
+                "@type": "Organization",
+                "name": "Air Street Capital",
+                "url": "https://www.airstreet.com/"
+              },
+              "keywords": [
+                "State of AI",
+                "State of AI Report",
+                "artificial intelligence",
+                "machine learning",
+                "deep learning",
+                "generative AI",
+                "AI research",
+                "AI industry",
+                "AI geopolitics",
+                "AI safety"
+              ],
+              "sameAs": [
+                "https://x.com/stateofai",
+                "https://www.linkedin.com/company/stateofai/",
+                "https://press.airstreet.com/",
+                "https://www.airstreet.com/"
+              ]
+            }
+          ]
+        }
+        </script>
+<!-- Google tag (gtag.js) -->
         <script async src="https://www.googletagmanager.com/gtag/js?id=G-25T8JQY0LN"></script>
         <script>
           window.dataLayer = window.dataLayer || [];
@@ -17,31 +72,7 @@
         'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
         })(window,document,'script','dataLayer','GTM-NWC2HDM');</script>
         <!-- End Google Tag Manager -->
-        <script type="application/ld+json">
-        {
-          "@context" : "http://schema.org",
-          "@type" : "Article",
-          "headline" : "A Report on the state of AI and its implication for the future.",
-          "name" : "State of AI Report",
-          "about" : "A Report on artificial intelligence research, talent, politics, industry, startups, and China.",
-          "description" : "A Report on artificial intelligence research, talent, politics, industry, startups, and China.",
-          "inLanguage" : "English",
-          "image" : "https://www.slideshare.net/StateofAIReport/state-of-ai-report-2019-151804430",
-          "keywords" : ["State of AI Report 2020", "State of AI Report 2018", "State of AI Report 2019", "artificial intelligence", "deep learning", "machine learning", "reinforcement learning", "supervised learning", "startups", "venture capital", "State of AI", "State of AI Report", "State of AI Report 2018"],
-          "publisher": {
-            "@type": "Organization",
-            "name": "Air Street Capital"
-          },
-          "author" : [ {
-            "@type" : "Person",
-            "name" : "Nathan Benaich"
-          },],
-          "datePublished" : "2019-06-28",
-          "articleBody" : "We believe that AI will be a force multiplier on technological progress in our increasingly digital, data-driven world. This is because everything around us today, ranging from culture to consumer products, is a product of intelligence.\n              </P>\n              <P class=\"subtext\">\n                In this report, we set out to capture a snapshot of the exponential progress in AI with a focus on developments in the past 12 months. Consider this report as a compilation of the most interesting things we’ve seen that seeks to trigger an informed conversation about the state of AI and its implication for the future. This edition builds on the inaugural State of AI Report 2018, which can be <A href=\"https://www.stateof.ai/2018\">found here</A>.\n              </P>\n              <OL> We consider the following key dimensions in our report:\n                  <LI><STRONG>Research:</STRONG> Technology breakthroughs and their capabilities. </LI>\n                  <LI><STRONG>Talent:</STRONG> Supply, demand and concentration of talent working in the field.  </LI>\n                  <LI><STRONG>Industry:</STRONG> Large platforms, financings and areas of application for AI-driven innovation today and tomorrow. </LI>\n                  <LI><STRONG>China:</STRONG> With two distinct internets, we review AI in China as its own category. </LI>\n                  <LI><STRONG>Politics:</STRONG> Public opinion of AI, economic implications and the emerging geopolitics of AI.",
-          "url" : "https://www.slideshare.net/StateofAIReport/state-of-ai-report-2019-151804430"
-        }
-        </script>
-        <title>State of AI Report 2025: AI Usage Survey</title>
+<title>State of AI Report 2025: AI Usage Survey</title>
         <meta charset="utf-8">
         <meta http-equiv="x-ua-compatible" content="ie=edge">
         <meta name="author" content="Nathan Benaich">

--- a/survey.html
+++ b/survey.html
@@ -1,7 +1,62 @@
 <!DOCTYPE html>
 <html class="no-js" lang="">
     <head>
-        <!-- Google tag (gtag.js) -->
+        <script type="application/ld+json">
+        {
+          "@context": "https://schema.org",
+          "@graph": [
+            {
+              "@type": "WebSite",
+              "@id": "https://www.stateof.ai/survey#website",
+              "url": "https://www.stateof.ai/",
+              "name": "State of AI Report",
+              "publisher": {
+                "@type": "Organization",
+                "name": "Air Street Capital",
+                "url": "https://www.airstreet.com/"
+              }
+            },
+            {
+              "@type": "CreativeWorkSeries",
+              "@id": "https://www.stateof.ai/survey#series",
+              "name": "State of AI Report",
+              "description": "The most widely read and trusted independent annual report on global progress in artificial intelligence, covering research, industry, geopolitics, and AI safety.",
+              "inLanguage": "en",
+              "startDate": "2018-01-01",
+              "url": "https://www.stateof.ai/survey",
+              "creator": {
+                "@type": "Person",
+                "name": "Nathan Benaich",
+                "url": "https://www.nathanbenaich.com/"
+              },
+              "publisher": {
+                "@type": "Organization",
+                "name": "Air Street Capital",
+                "url": "https://www.airstreet.com/"
+              },
+              "keywords": [
+                "State of AI",
+                "State of AI Report",
+                "artificial intelligence",
+                "machine learning",
+                "deep learning",
+                "generative AI",
+                "AI research",
+                "AI industry",
+                "AI geopolitics",
+                "AI safety"
+              ],
+              "sameAs": [
+                "https://x.com/stateofai",
+                "https://www.linkedin.com/company/stateofai/",
+                "https://press.airstreet.com/",
+                "https://www.airstreet.com/"
+              ]
+            }
+          ]
+        }
+        </script>
+<!-- Google tag (gtag.js) -->
         <script async src="https://www.googletagmanager.com/gtag/js?id=G-25T8JQY0LN"></script>
         <script>
           window.dataLayer = window.dataLayer || [];
@@ -17,32 +72,7 @@
         'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
         })(window,document,'script','dataLayer','GTM-NWC2HDM');</script>
         <!-- End Google Tag Manager -->
-        <script type="application/ld+json">
-        {
-          "@context" : "http://schema.org",
-          "@type" : "Article",
-          "headline" : "A Report on the state of AI and its implication for the future.",
-          "name" : "State of AI Report",
-          "about" : "A Report on artificial intelligence research, talent, politics, industry, startups, and China.",
-          "description" : "A Report on artificial intelligence research, talent, politics, industry, startups, and China.",
-          "inLanguage" : "English",
-          "image" : "https://www.slideshare.net/StateofAIReport/state-of-ai-report-2019-151804430",
-          "keywords" : ["State of AI Report 2020", "State of AI Report 2018", "State of AI Report 2019", "artificial intelligence", "deep learning", "machine learning", "reinforcement learning", "supervised learning", "startups", "venture capital", "State of AI", "State of AI Report", "State of AI Report 2018"],
-          "publisher": {
-            "@type": "Organization",
-            "name": "Air Street Capital"
-          },
-          "author" : [ {
-            "@type" : "Person",
-            "name" : "Nathan Benaich"
-          }, 
-          ],
-          "datePublished" : "2019-06-28",
-          "articleBody" : "We believe that AI will be a force multiplier on technological progress in our increasingly digital, data-driven world. This is because everything around us today, ranging from culture to consumer products, is a product of intelligence.\n              </P>\n              <P class=\"subtext\">\n                In this report, we set out to capture a snapshot of the exponential progress in AI with a focus on developments in the past 12 months. Consider this report as a compilation of the most interesting things we’ve seen that seeks to trigger an informed conversation about the state of AI and its implication for the future. This edition builds on the inaugural State of AI Report 2018, which can be <A href=\"https://www.stateof.ai/2018\">found here</A>.\n              </P>\n              <OL> We consider the following key dimensions in our report:\n                  <LI><STRONG>Research:</STRONG> Technology breakthroughs and their capabilities. </LI>\n                  <LI><STRONG>Talent:</STRONG> Supply, demand and concentration of talent working in the field.  </LI>\n                  <LI><STRONG>Industry:</STRONG> Large platforms, financings and areas of application for AI-driven innovation today and tomorrow. </LI>\n                  <LI><STRONG>China:</STRONG> With two distinct internets, we review AI in China as its own category. </LI>\n                  <LI><STRONG>Politics:</STRONG> Public opinion of AI, economic implications and the emerging geopolitics of AI.",
-          "url" : "https://www.slideshare.net/StateofAIReport/state-of-ai-report-2019-151804430"
-        }
-        </script>
-        <title>State of AI Report 2025</title>
+<title>State of AI Report 2025</title>
         <meta charset="utf-8">
         <meta http-equiv="x-ua-compatible" content="ie=edge">
         <meta name="author" content="Nathan Benaich and Ian Hogarth">

--- a/talent.html
+++ b/talent.html
@@ -1,7 +1,62 @@
 <!DOCTYPE html>
 <html class="no-js" lang="">
     <head>
-        <!-- Google tag (gtag.js) -->
+        <script type="application/ld+json">
+        {
+          "@context": "https://schema.org",
+          "@graph": [
+            {
+              "@type": "WebSite",
+              "@id": "https://www.stateof.ai/talent#website",
+              "url": "https://www.stateof.ai/",
+              "name": "State of AI Report",
+              "publisher": {
+                "@type": "Organization",
+                "name": "Air Street Capital",
+                "url": "https://www.airstreet.com/"
+              }
+            },
+            {
+              "@type": "CreativeWorkSeries",
+              "@id": "https://www.stateof.ai/talent#series",
+              "name": "State of AI Report",
+              "description": "The most widely read and trusted independent annual report on global progress in artificial intelligence, covering research, industry, geopolitics, and AI safety.",
+              "inLanguage": "en",
+              "startDate": "2018-01-01",
+              "url": "https://www.stateof.ai/talent",
+              "creator": {
+                "@type": "Person",
+                "name": "Nathan Benaich",
+                "url": "https://www.nathanbenaich.com/"
+              },
+              "publisher": {
+                "@type": "Organization",
+                "name": "Air Street Capital",
+                "url": "https://www.airstreet.com/"
+              },
+              "keywords": [
+                "State of AI",
+                "State of AI Report",
+                "artificial intelligence",
+                "machine learning",
+                "deep learning",
+                "generative AI",
+                "AI research",
+                "AI industry",
+                "AI geopolitics",
+                "AI safety"
+              ],
+              "sameAs": [
+                "https://x.com/stateofai",
+                "https://www.linkedin.com/company/stateofai/",
+                "https://press.airstreet.com/",
+                "https://www.airstreet.com/"
+              ]
+            }
+          ]
+        }
+        </script>
+<!-- Google tag (gtag.js) -->
         <script async src="https://www.googletagmanager.com/gtag/js?id=G-25T8JQY0LN"></script>
         <script>
           window.dataLayer = window.dataLayer || [];
@@ -17,31 +72,7 @@
         'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
         })(window,document,'script','dataLayer','GTM-NWC2HDM');</script>
         <!-- End Google Tag Manager -->
-        <script type="application/ld+json">
-        {
-          "@context" : "http://schema.org",
-          "@type" : "Article",
-          "headline" : "A Report on the state of AI and its implication for the future.",
-          "name" : "State of AI Report",
-          "about" : "A Report on artificial intelligence research, talent, politics, industry, startups, and China.",
-          "description" : "A Report on artificial intelligence research, talent, politics, industry, startups, and China.",
-          "inLanguage" : "English",
-          "image" : "https://www.slideshare.net/StateofAIReport/state-of-ai-report-2019-151804430",
-          "keywords" : ["State of AI Report 2020", "State of AI Report 2018", "State of AI Report 2019", "artificial intelligence", "deep learning", "machine learning", "reinforcement learning", "supervised learning", "startups", "venture capital", "State of AI", "State of AI Report", "State of AI Report 2018"],
-          "publisher": {
-            "@type": "Organization",
-            "name": "Air Street Capital"
-          },
-          "author" : [ {
-            "@type" : "Person",
-            "name" : "Nathan Benaich"
-          },],
-          "datePublished" : "2019-06-28",
-          "articleBody" : "We believe that AI will be a force multiplier on technological progress in our increasingly digital, data-driven world. This is because everything around us today, ranging from culture to consumer products, is a product of intelligence.\n              </P>\n              <P class=\"subtext\">\n                In this report, we set out to capture a snapshot of the exponential progress in AI with a focus on developments in the past 12 months. Consider this report as a compilation of the most interesting things we’ve seen that seeks to trigger an informed conversation about the state of AI and its implication for the future. This edition builds on the inaugural State of AI Report 2018, which can be <A href=\"https://www.stateof.ai/2018\">found here</A>.\n              </P>\n              <OL> We consider the following key dimensions in our report:\n                  <LI><STRONG>Research:</STRONG> Technology breakthroughs and their capabilities. </LI>\n                  <LI><STRONG>Talent:</STRONG> Supply, demand and concentration of talent working in the field.  </LI>\n                  <LI><STRONG>Industry:</STRONG> Large platforms, financings and areas of application for AI-driven innovation today and tomorrow. </LI>\n                  <LI><STRONG>China:</STRONG> With two distinct internets, we review AI in China as its own category. </LI>\n                  <LI><STRONG>Politics:</STRONG> Public opinion of AI, economic implications and the emerging geopolitics of AI.",
-          "url" : "https://www.slideshare.net/StateofAIReport/state-of-ai-report-2019-151804430"
-        }
-        </script>
-        <title>State of AI Report 2025</title>
+<title>State of AI Report 2025</title>
         <meta charset="utf-8">
         <meta http-equiv="x-ua-compatible" content="ie=edge">
         <meta name="author" content="Nathan Benaich and Ian Hogarth">


### PR DESCRIPTION
## Summary
- replace each page's JSON-LD with the shared @graph schema (WebSite and CreativeWorkSeries) used on the homepage
- apply page-specific URLs and @id anchors while preserving site-wide creator/publisher metadata and shared keywords/sameAs links
- place the structured data block at the start of each head to avoid duplicates before other scripts load

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694ff7cb72188328a98d9e12952ee4c2)